### PR TITLE
Auto unwrap HttpUnhandledException

### DIFF
--- a/Mindscape.Raygun4Net/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net/RaygunHttpModule.cs
@@ -17,12 +17,17 @@ namespace Mindscape.Raygun4Net
     private void SendError(object sender, EventArgs e)
     {
       var application = (HttpApplication)sender;
+      new RaygunClient().Send(Unwrap(application.Server.GetLastError()));
+    }
 
-      var exception = application.Server.GetLastError();
+    private Exception Unwrap(Exception exception)
+    {
+      if (exception is HttpUnhandledException)
+      {
+        return exception.GetBaseException();
+      }
 
-      var raygunClient = new RaygunClient();
-
-      raygunClient.Send(exception);
+      return exception;
     }
   }
 }


### PR DESCRIPTION
The module will typically be seeing HttpUnhandledExceptions which
contain the useful exception details in .GetBaseException().
Automatically unwrap this before sending it to Raygun.
