### PR TITLE
Add a build target for pushing the nuget package to nuget.org.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,3 @@
-call .\packages\psake.4.2.0.1\tools\psake.cmd build.ps1
+call .\packages\psake.4.2.0.1\tools\psake.cmd build.ps1 %*
 
 pause

--- a/build.ps1
+++ b/build.ps1
@@ -4,6 +4,7 @@ properties {
     $rayguntests_project =  "$root/Mindscape.Raygun4Net.Tests/Mindscape.Raygun4Net.Tests.csproj"
     $raygunwinrt_project =  "$root/Mindscape.Raygun4Net.WinRT/Mindscape.Raygun4Net.WinRT.csproj"
     $nugetspec =            "$root/Mindscape.Raygun4Net.nuspec"
+    $nugetpackage =         "Mindscape.Raygun4Net.1.0.nupkg"
     $configuration =        "Debug"
     $build_dir =            "$root\build\"
     $release_dir =          "$root\release\"
@@ -64,6 +65,14 @@ task Package -depends Merge {
     Copy-Item $root\README.md .\readme.txt
 
     exec { nuget pack $nugetspec }
+
+    Pop-Location
+}
+
+task PushNugetPackage -depends Package {
+    Push-Location -Path $release_dir    
+
+    exec { nuget push "$release_dir$nugetpackage" }
 
     Pop-Location
 }


### PR DESCRIPTION
This depends on having run "NuGet SetApiKey Your-API-Key" on the machine before using this target.

Target needs to be manually specified by: build.bat PushNugetPackage
