### PR TITLE
Add public constructor to RaygunErrorMessage

### DIFF
--- a/Mindscape.Raygun4Net/Messages/RaygunErrorMessage.cs
+++ b/Mindscape.Raygun4Net/Messages/RaygunErrorMessage.cs
@@ -19,6 +19,10 @@ namespace Mindscape.Raygun4Net.Messages
 
     public RaygunErrorStackTraceLineMessage[] StackTrace { get; set; }
 
+    public RaygunErrorMessage()
+    {
+    }
+
     public RaygunErrorMessage(Exception exception)
     {
       var exceptionType = exception.GetType();


### PR DESCRIPTION
So I can construct without using the stack
