### PR TITLE
Refactored tags in WinRT to be optionally transmitted in Send()

### DIFF
--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Runtime.InteropServices;
 using Mindscape.Raygun4Net.Messages;
 #if !WINRT
 using Newtonsoft.Json;
@@ -55,29 +56,19 @@ namespace Mindscape.Raygun4Net
 
 #if WINRT
     /// <summary>
-    /// A collection of string tags that represent custom data about the version of the program
-    /// that caused the message to be sent.
+    /// Sends the exception from an UnhandledException event to Raygun.io, optionally with a list of tags
+    /// for identification.
     /// </summary>
-    public List<string> Tags { get; set; }    
-
-    public void Send(UnhandledExceptionEventArgs unhandledExceptionEventArgs)
+    /// <param name="unhandledExceptionEventArgs">The event args from UnhandledException, containing the thrown exception and its message.</param>
+    /// <param name="tags">An optional list of strings to identify the message to be transmitted.</param>
+    public void Send(UnhandledExceptionEventArgs unhandledExceptionEventArgs, [Optional] List<string> tags)
     {
       if (ValidateApiKey())
       {
-        //var exception = new Exception(unhandledExceptionEventArgs.Message, unhandledExceptionEventArgs.Exception);
-
         var exception = unhandledExceptionEventArgs.Exception;
         exception.Data.Add("Message", unhandledExceptionEventArgs.Message);
-                 
-        var message = RaygunMessageBuilder.New
-          .SetEnvironmentDetails()
-          .SetMachineName(NetworkInformation.GetHostNames()[0].DisplayName)
-          .SetExceptionDetails(exception)
-          .SetClientDetails()
-          .SetVersion()
-          .Build();        
 
-        Send(message);
+        Send(CreateMessage(exception, tags));
       }
     }
 
@@ -86,29 +77,17 @@ namespace Mindscape.Raygun4Net
     /// as the object contains little useful information besides the exception name and description
     /// </summary>
     /// <param name="exception">The exception thrown by the wrapped method</param>
-    private void Send(Exception exception)
+    /// <param name="tags">A list of string tags relating to the message to identify it</param>
+    private void Send(Exception exception, [Optional] List<string> tags)
     {
       if (ValidateApiKey())
-      {        
-        var message = RaygunMessageBuilder.New
-          .SetEnvironmentDetails()
-          .SetMachineName(NetworkInformation.GetHostNames()[0].DisplayName)
-          .SetExceptionDetails(exception)
-          .SetClientDetails()
-          .SetVersion()
-          .Build();
-
-        Send(message);
+      {
+        Send(CreateMessage(exception, tags));
       }
     }
 
     public async void Send(RaygunMessage raygunMessage)
     {
-      if (Tags != null)
-      {
-        raygunMessage.Details.Tags = Tags;
-      }
-
       HttpClientHandler handler = new HttpClientHandler();
       handler.UseDefaultCredentials = true;
 
@@ -129,7 +108,23 @@ namespace Mindscape.Raygun4Net
           System.Diagnostics.Debug.WriteLine(string.Format("Error Logging Exception to Raygun.io {0}", ex.Message));
         }
       }
+    }
 
+    private RaygunMessage CreateMessage(Exception exception, [Optional] List<string> tags)
+    {
+      var message = RaygunMessageBuilder.New
+          .SetEnvironmentDetails()
+          .SetMachineName(NetworkInformation.GetHostNames()[0].DisplayName)
+          .SetExceptionDetails(exception)
+          .SetClientDetails()
+          .SetVersion()
+          .Build();
+
+      if (tags != null)
+      {
+        message.Details.Tags = tags;
+      }
+      return message;
     }
 
 #pragma warning disable 1998
@@ -141,7 +136,7 @@ namespace Mindscape.Raygun4Net
       client.Dispose();
     }
 
-    public void Wrap(Action func)
+    public void Wrap(Action func, [Optional] List<string> tags)
     {
       try
       {
@@ -154,7 +149,7 @@ namespace Mindscape.Raygun4Net
       }
     }
 
-    public TResult Wrap<TResult>(Func<TResult> func)
+    public TResult Wrap<TResult>(Func<TResult> func, [Optional] List<string> tags)
     {
       try
       {
@@ -166,8 +161,7 @@ namespace Mindscape.Raygun4Net
         throw;
       }
     }
-#else
-
+#else    
     public void Send(Exception exception)
     {      
       Send(BuildMessage(exception));


### PR DESCRIPTION
Here it is - it actually was for the WinRT section. The tags are no longer set in that property, and can be now set by passing in in Send() with that optional list<string>.
