### PR TITLE
Build script and nuget now automatically grabs missing dependencies

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,4 @@
+set EnableNuGetPackageRestore=true
 call .\packages\psake.4.2.0.1\tools\psake.cmd build.ps1 %*
 
 pause


### PR DESCRIPTION
This fixes the build script throwing errors if the option in VS Package Manager 'Allow NuGet to download missing packages during build' hasn't been checked
