### PR TITLE
Add throwOnError setting

### DIFF
--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -95,7 +95,6 @@ namespace Mindscape.Raygun4Net
         client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("raygun4net-winrt", "1.0.0"));
 
         HttpContent httpContent = new StringContent(SimpleJson.SerializeObject(raygunMessage));
-        //HttpContent httpContent = new StringContent(JObject.FromObject(raygunMessage, new JsonSerializer { MissingMemberHandling = MissingMemberHandling.Ignore }).ToString());
         httpContent.Headers.ContentType = new MediaTypeHeaderValue("application/x-raygun-message");
         httpContent.Headers.Add("X-ApiKey", _apiKey);
 
@@ -106,6 +105,11 @@ namespace Mindscape.Raygun4Net
         catch (Exception ex)
         {
           System.Diagnostics.Debug.WriteLine(string.Format("Error Logging Exception to Raygun.io {0}", ex.Message));
+
+          if (RaygunSettings.Settings.ThrowOnError)
+          {
+            throw;
+          }
         }
       }
     }
@@ -165,7 +169,7 @@ namespace Mindscape.Raygun4Net
         throw;
       }
     }
-#else    
+#else
     /// <summary>
     /// Transmits an exception to Raygun.io synchronously, using the version number of the originating assembly.
     /// </summary>
@@ -287,8 +291,13 @@ namespace Mindscape.Raygun4Net
             client.UploadString(RaygunSettings.Settings.ApiEndpoint, message);
           }
           catch (Exception ex)
-          {
+          {            
             System.Diagnostics.Trace.WriteLine(string.Format("Error Logging Exception to Raygun.io {0}", ex.Message));
+
+            if (RaygunSettings.Settings.ThrowOnError)
+            {
+              throw;
+            }
           }
         }
       }

--- a/Mindscape.Raygun4Net/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net/RaygunSettings.cs
@@ -38,7 +38,14 @@ namespace Mindscape.Raygun4Net
     {
       get { return (bool)this["mediumTrust"]; }
       set { this["mediumTrust"] = value; }
-    }    
+    }
+
+    [ConfigurationProperty("throwOnError", IsRequired = false, DefaultValue = false)]
+    public bool ThrowOnError
+    {
+      get { return (bool)this["throwOnError"]; }
+      set { this["throwOnError"] = value; }
+    } 
   }
 }
 #else


### PR DESCRIPTION
Added new setting throwOnError which will have the client rethrow any
exception it encountered when calling Send(). This can be used for
debugging or if you wish to run the client in a fail fast manner.
