### PR TITLE
Handle missing Request object during Application_Start

### DIFF
--- a/Mindscape.Raygun4Net/Messages/RaygunRequestMessage.cs
+++ b/Mindscape.Raygun4Net/Messages/RaygunRequestMessage.cs
@@ -9,24 +9,24 @@ namespace Mindscape.Raygun4Net.Messages
 {
   public class RaygunRequestMessage
   {
-    public RaygunRequestMessage(HttpContext context)
+    public RaygunRequestMessage(HttpRequest	request)
     {
-      HostName = context.Request.Url.Host;
-      Url = context.Request.Url.AbsolutePath;
-      HttpMethod = context.Request.RequestType;
-      IPAddress = context.Request.UserHostAddress;
-      Data = ToDictionary(context.Request.ServerVariables);
-      QueryString = ToDictionary(context.Request.QueryString);
-      Headers = ToDictionary(context.Request.Headers);
-      Form = ToDictionary(context.Request.Form, true);
+      HostName = request.Url.Host;
+      Url = request.Url.AbsolutePath;
+      HttpMethod = request.RequestType;
+      IPAddress = request.UserHostAddress;
+      Data = ToDictionary(request.ServerVariables);
+      QueryString = ToDictionary(request.QueryString);
+      Headers = ToDictionary(request.Headers);
+      Form = ToDictionary(request.Form, true);
 
       try
       {
-        var contentType = context.Request.Headers["Content-Type"];
-        if (contentType != "text/html" && contentType != "application/x-www-form-urlencoded" && context.Request.RequestType != "GET")
+        var contentType = request.Headers["Content-Type"];
+        if (contentType != "text/html" && contentType != "application/x-www-form-urlencoded" && request.RequestType != "GET")
         {
           int length = 4096;
-          string temp = new StreamReader(context.Request.InputStream).ReadToEnd();
+          string temp = new StreamReader(request.InputStream).ReadToEnd();
           if (length > temp.Length)
           {
             length = temp.Length;

--- a/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
@@ -91,12 +91,21 @@ namespace Mindscape.Raygun4Net
 #else
     public IRaygunMessageBuilder SetHttpDetails(HttpContext context)
     {
-      if (context != null)
-      {
-        _raygunMessage.Details.Request = new RaygunRequestMessage(context);
-      }
+	    if(context != null)
+	    {
+		    HttpRequest request;
+		    try
+		    {
+			    request = context.Request;
+		    }
+		    catch (HttpException)
+		    {
+			    return this;
+		    }
+		    _raygunMessage.Details.Request = new RaygunRequestMessage(request);
+	    }
 
-      return this;
+	    return this;
     }
 
     public IRaygunMessageBuilder SetVersion()


### PR DESCRIPTION
Factor out repeated calls to context.Request in Message object; catch and swallow "Request is not available in this context" HttpException that occurs in IIS Integrated Mode during Application_Start and End.

It is not possible to detect from the HttpContext object alone whether the Request is available except by catching the exception upon access or reading an internal property.
http://stackoverflow.com/questions/2609512/

Did not add tests for this because it requires integration testing with an actual web app that throws an exception during Start or End events.  
