### PR TITLE
add settings parameter to exclude form parameters from error report

### DIFF
--- a/Mindscape.Raygun4Net/Messages/RaygunRequestMessage.cs
+++ b/Mindscape.Raygun4Net/Messages/RaygunRequestMessage.cs
@@ -19,7 +19,7 @@ namespace Mindscape.Raygun4Net.Messages
       Data = ToDictionary(request.ServerVariables);
       QueryString = ToDictionary(request.QueryString);
       Headers = ToDictionary(request.Headers);
-      Form = ToDictionary(request.Form, true);
+      Form = RaygunSettings.Settings.ExcludeFormParameters ? new Dictionary<string,string>() : ToDictionary(request.Form, true);
 
       try
       {

--- a/Mindscape.Raygun4Net/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net/RaygunSettings.cs
@@ -70,6 +70,7 @@ namespace Mindscape.Raygun4Net
 }
 #else
 using System.Configuration;
+
 namespace Mindscape.Raygun4Net
 {
   public class RaygunSettings : ConfigurationSection
@@ -122,6 +123,13 @@ namespace Mindscape.Raygun4Net
     {
       get { return (string)this["excludeHttpStatusCodes"]; }
       set { this["excludeHttpStatusCodes"] = value; }
+    }
+
+    [ConfigurationProperty("excludeFormParameters", IsRequired = false, DefaultValue = false)]
+    public bool ExcludeFormParameters
+    {
+        get { return (bool)this["excludeFormParameters"]; }
+        set { this["excludeFormParameters"] = value; }
     }
   }
 }


### PR DESCRIPTION
We need a way to prevent form values from being submitted as part of the error report, as we need to be PCI-compliant.

Ideally, we could indicate specific parameters to suppress, but this simply lets the config turn the form parameters on or off.
