### PR TITLE
populate the http response section correctly

### DIFF
--- a/Mindscape.Raygun4Net/Messages/RaygunResponseMessage.cs
+++ b/Mindscape.Raygun4Net/Messages/RaygunResponseMessage.cs
@@ -8,10 +8,11 @@ namespace Mindscape.Raygun4Net.Messages
 {
   public class RaygunResponseMessage
   {
-    public RaygunResponseMessage(HttpResponse response)
+    public RaygunResponseMessage(Exception exception)
     {
-      StatusCode = response.StatusCode;
-      StatusDescription = response.StatusDescription;
+      var httpException = new HttpException(null, exception);
+
+      StatusCode = httpException.GetHttpCode();
     }
 
     public int StatusCode { get; set; }

--- a/Mindscape.Raygun4Net/Messages/RaygunResponseMessage.cs
+++ b/Mindscape.Raygun4Net/Messages/RaygunResponseMessage.cs
@@ -8,6 +8,12 @@ namespace Mindscape.Raygun4Net.Messages
 {
   public class RaygunResponseMessage
   {
+    public RaygunResponseMessage(HttpResponse response)
+    {
+      StatusCode = response.StatusCode;
+      StatusDescription = response.StatusDescription;
+    }
+
     public int StatusCode { get; set; }
 
     public string StatusDescription { get; set; }

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -177,7 +177,7 @@ namespace Mindscape.Raygun4Net
       exception = StripWrapperExceptions(exception);
 
       var message = RaygunMessageBuilder.New
-        .SetHttpDetails(HttpContext.Current, _ignoredFormNames)
+        .SetHttpDetails(HttpContext.Current, exception, _ignoredFormNames)
         .SetEnvironmentDetails()
         .SetMachineName(Environment.MachineName)
         .SetExceptionDetails(exception)

--- a/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
@@ -63,32 +63,6 @@ namespace Mindscape.Raygun4Net
         _raygunMessage.Details.Error = new RaygunErrorMessage(exception);
       }
 
-      HttpException error = exception as HttpException;
-      if (error != null)
-      {
-        int code = error.GetHttpCode();
-        string description = null;
-        if (Enum.IsDefined(typeof(HttpStatusCode), code))
-        {
-          description = ((HttpStatusCode)code).ToString();
-        }
-        _raygunMessage.Details.Response = new RaygunResponseMessage() { StatusCode = code, StatusDescription = description };
-      }
-
-      WebException webError = exception as WebException;
-      if (webError != null)
-      {
-        if (webError.Status == WebExceptionStatus.ProtocolError)
-        {
-          HttpWebResponse response = (HttpWebResponse)webError.Response;
-          _raygunMessage.Details.Response = new RaygunResponseMessage() { StatusCode = (int)response.StatusCode, StatusDescription = response.StatusDescription };
-        }
-        else
-        {
-          _raygunMessage.Details.Response = new RaygunResponseMessage() { StatusDescription = webError.Status.ToString() };
-        }
-      }
-
       return this;
     }
 
@@ -124,15 +98,18 @@ namespace Mindscape.Raygun4Net
       if (context != null)
       {
         HttpRequest request;
+        HttpResponse response;
         try
         {
           request = context.Request;
+          response = context.Response;
         }
         catch (HttpException)
         {
           return this;
         }
         _raygunMessage.Details.Request = new RaygunRequestMessage(request, ignoredFormNames);
+        _raygunMessage.Details.Response = new RaygunResponseMessage(response);
       }
 
       return this;

--- a/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
@@ -63,6 +63,8 @@ namespace Mindscape.Raygun4Net
         _raygunMessage.Details.Error = new RaygunErrorMessage(exception);
       }
 
+      _raygunMessage.Details.Response = new RaygunResponseMessage(exception);
+
       return this;
     }
 
@@ -95,21 +97,27 @@ namespace Mindscape.Raygun4Net
 
     public IRaygunMessageBuilder SetHttpDetails(HttpContext context, List<string> ignoredFormNames = null)
     {
+      return SetHttpDetails(context, null, ignoredFormNames);
+    }
+
+    public IRaygunMessageBuilder SetHttpDetails(HttpContext context, Exception exception, List<string> ignoredFormNames = null)
+    {
       if (context != null)
       {
         HttpRequest request;
-        HttpResponse response;
         try
         {
           request = context.Request;
-          response = context.Response;
         }
         catch (HttpException)
         {
           return this;
         }
         _raygunMessage.Details.Request = new RaygunRequestMessage(request, ignoredFormNames);
-        _raygunMessage.Details.Response = new RaygunResponseMessage(response);
+        if (exception != null)
+        {
+          _raygunMessage.Details.Response = new RaygunResponseMessage(exception);
+        }
       }
 
       return this;


### PR DESCRIPTION
resolves #117. Previously we were relying on an HttpException to be
thrown to grab the status code of the response. We should be taking
this off of the HttpContext Response. Not sure what the
StatusDescription is required for we as should be able to generate
that off of the Code but will leave in for backwards compatibility.
