### PR TITLE
Removes apparently unused permission to access external storage.

### DIFF
--- a/Mindscape.Raygun4Net.Xamarin.Android/Properties/AssemblyInfo.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Android/Properties/AssemblyInfo.cs
@@ -19,4 +19,3 @@ using Android.App;
 // Add some common permissions, these can be removed if not needed
 [assembly: UsesPermission(Android.Manifest.Permission.Internet)]
 [assembly: UsesPermission(Android.Manifest.Permission.AccessNetworkState)]
-[assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]


### PR DESCRIPTION
This permission is included in the Xamarin.Android project template, so it probably just came from there.
