### PR TITLE
Adds to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ local.properties
 *.suo
 *.user
 *.sln.docstates
+*.ide
 
 # Build results
 [Dd]ebug/
@@ -62,6 +63,7 @@ local.properties
 *.vspscc
 .builds
 *.dotCover
+*.log
 
 ## TODO: If you have NuGet Package Restore enabled, uncomment this
 packages/


### PR DESCRIPTION
MSBuild drops .log files when built from command line usually.
Roslyn adds the *.ide directories.
