### PR TITLE
exclude errors that originate from a local origin

### DIFF
--- a/Mindscape.Raygun4Net/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net/RaygunHttpModule.cs
@@ -7,6 +7,7 @@ namespace Mindscape.Raygun4Net
   public class RaygunHttpModule : IHttpModule
   {
     private bool ExcludeErrorsBasedOnHttpStatusCode { get; set; }
+    private bool ExcludeErrorsFromLocal { get; set; }
 
     private int[] HttpStatusCodesToExclude { get; set; }
 
@@ -15,6 +16,7 @@ namespace Mindscape.Raygun4Net
       context.Error += SendError;
       HttpStatusCodesToExclude = string.IsNullOrEmpty(RaygunSettings.Settings.ExcludeHttpStatusCodesList) ? new int[0] : RaygunSettings.Settings.ExcludeHttpStatusCodesList.Split(',').Select(int.Parse).ToArray();
       ExcludeErrorsBasedOnHttpStatusCode = HttpStatusCodesToExclude.Any();
+      ExcludeErrorsFromLocal = RaygunSettings.Settings.ExcludeErrorsFromLocal;
     }
 
     public void Dispose()
@@ -27,6 +29,11 @@ namespace Mindscape.Raygun4Net
       var lastError = application.Server.GetLastError();
 
       if (ExcludeErrorsBasedOnHttpStatusCode && lastError is HttpException && HttpStatusCodesToExclude.Contains(((HttpException)lastError).GetHttpCode()))
+      {
+        return;
+      }
+
+      if (ExcludeErrorsFromLocal && HttpContext.Current.Request.IsLocal)
       {
         return;
       }

--- a/Mindscape.Raygun4Net/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net/RaygunSettings.cs
@@ -53,6 +53,14 @@ namespace Mindscape.Raygun4Net
     {
       get { return (string)this["excludeHttpStatusCodes"]; }
       set { this["excludeHttpStatusCodes"] = value; }
+
+    }
+
+    [ConfigurationProperty("excludeErrorsFromLocal", IsRequired = false, DefaultValue = false)]
+    public bool ExcludeErrorsFromLocal
+    {
+      get { return (bool)this["excludeErrorsFromLocal"]; }
+      set { this["excludeErrorsFromLocal"] = value; }
     }
 
     [ConfigurationProperty("ignoreFormDataNames", IsRequired = false, DefaultValue = "")]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ If using the HTTP module then you can exclude errors by their HTTP status code b
 <RaygunSettings apikey="YOUR_APP_API_KEY" excludeHttpStatusCodes="418" />
 ```
 
+**Exclude errors that originate from a local origin**
+
+Toggle this boolean and the HTTP module will not send errors to RayGun.io if the request originated from a local origin. ie. A way to prevent local debug/development from notifying Raygun without having to resort to Web.config transforms.
+
+```
+<RaygunSettings apikey="YOUR_APP_API_KEY" excludeErrorsFromLocal=true />
+```
+
 **Remove sensitive request data**
 
 If you have sensitive data in an HTTP request that you wish to prevent being transmitted to Raygun, you can provide a list of possible keys (Names) to remove:


### PR DESCRIPTION
Toggle this boolean and the HTTP module will not send errors to
RayGun.io if the request originated from a local origin. ie. A way to
prevent local debug/development from notifying Raygun without having to
resort to Web.config transforms.

```
<RaygunSettings apikey="YOUR_APP_API_KEY" excludeErrorsFromLocal=true />
```

Released under license at @/LICENSE
