### PR TITLE
Added a just-before-sending filter for RaygunMessages.

### DIFF
--- a/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
@@ -26,5 +26,10 @@ namespace Mindscape.Raygun4Net.Tests
     {
       return ValidateApiKey();
     }
+
+    public bool ExposeFilterShouldPreventSend(RaygunMessage raygunMessage)
+    {
+        return FilterShouldPreventSend(raygunMessage);
+    }
   }
 }

--- a/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
@@ -179,5 +179,29 @@ namespace Mindscape.Raygun4Net.Tests
       Assert.AreEqual("42", message.Details.UserCustomData["x"]);
       Assert.AreEqual("NULL", message.Details.UserCustomData["obj"]);
     }
+
+
+    // Filter tests
+
+    [Test]
+    public void NoFilterPassesAll()
+    {
+      RaygunClient.MessageSendFilter = null;
+      Assert.IsFalse(_client.ExposeFilterShouldPreventSend(_client.CreateMessage(_exception)));
+    }
+
+    [Test]
+    public void FilterIsChecked()
+    {
+      bool filterCalled = false;
+      RaygunClient.MessageSendFilter = x =>
+      {
+        Assert.AreEqual("NullReferenceException: The thing is null", x.Details.Error.Message);
+        filterCalled = true;
+        return false;
+      };
+      Assert.IsTrue(_client.ExposeFilterShouldPreventSend(_client.CreateMessage(_exception)));
+      Assert.IsTrue(filterCalled);
+    }
   }
 }


### PR DESCRIPTION
I don't like that it's a static Func, but I couldn't think of any better options that would be picked up by the RaygunHttpModule.

We need this for security reasons, to add a second layer of checks over the standard IgnoreFormNames. The advantages of providing custom code (instead of strings in config) for this are:
- We can cancel an entire message
- We can log an error if the app tries to send any form variable that matches a particular regex (such as a credit card number)
- We can mutate the message before sending - for example anonymize a section of a single value
