### PR TITLE
Add HTTP Method to WebApi response code exceptions

### DIFF
--- a/Mindscape.Raygun4Net45/WebApi/RaygunWebApiFilters.cs
+++ b/Mindscape.Raygun4Net45/WebApi/RaygunWebApiFilters.cs
@@ -55,6 +55,7 @@ namespace Mindscape.Raygun4Net.WebApi
         }
         catch (Exception e)
         {
+          // This is here on the off chance that interacting with the context or HTTP Response throws an exception.
           _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(context.Request).Send(e);
         }
       }


### PR DESCRIPTION
Should make it a bit easier to debug 404 errors where a route is being missed for some reason
