### PR TITLE
Improve performance in getting the cpu name and os version in RayGunEnvironmentMessage

### DIFF
--- a/Mindscape.Raygun4Net/Messages/RaygunEnvironmentMessage.cs
+++ b/Mindscape.Raygun4Net/Messages/RaygunEnvironmentMessage.cs
@@ -58,14 +58,15 @@ namespace Mindscape.Raygun4Net.Messages
 
     private string GetCpu()
     {
-      ManagementClass wmiManagementProcessorClass = new ManagementClass("Win32_Processor");
-      ManagementObjectCollection wmiProcessorCollection = wmiManagementProcessorClass.GetInstances();
+
+      ManagementObjectSearcher wmiProcessorSearcher = new ManagementObjectSearcher("SELECT Name FROM Win32_Processor");
+      ManagementObjectCollection wmiProcessorCollection = wmiProcessorSearcher.Get();
 
       foreach (ManagementObject wmiProcessorObject in wmiProcessorCollection)
       {
         try
         {
-          var name = wmiProcessorObject.Properties["Name"].Value.ToString();
+          var name = wmiProcessorObject["Name"].ToString();
           return name;
         }
         catch (ManagementException)
@@ -77,14 +78,14 @@ namespace Mindscape.Raygun4Net.Messages
 
     private string GetOSVersion()
     {
-      ManagementClass wmiManagementOperatingSystemClass = new ManagementClass("Win32_OperatingSystem");
-      ManagementObjectCollection wmiOperatingSystemCollection = wmiManagementOperatingSystemClass.GetInstances();
+      ManagementObjectSearcher wmiOperatingSystemSearcher = new ManagementObjectSearcher("SELECT Version FROM Win32_OperatingSystem");
+      ManagementObjectCollection wmiOperatingSystemCollection = wmiOperatingSystemSearcher.Get();
 
       foreach (ManagementObject wmiOperatingSystemObject in wmiOperatingSystemCollection)
       {
         try
         {
-          var version = wmiOperatingSystemObject.Properties["Version"].Value.ToString();
+          var version = wmiOperatingSystemObject["Version"].ToString();
           return version;
         }
         catch (ManagementException)


### PR DESCRIPTION
The current code queries 40+ processor variables, when we only need one - the processor Name.  This can be very slow on some older machines(i.e. Windows Server 2003) due to WMI calculating the LoadPercentage property.
http://stackoverflow.com/questions/5465653/wmi-loadpercentage-call-is-very-slow

Making a change to only query the properties we need, the processor name and the os version.  This eliminates WMI having to load all the other unused property values
