### PR TITLE
Set UserInfo per Send

### DIFF
--- a/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
@@ -17,9 +17,9 @@ namespace Mindscape.Raygun4Net.Tests
     {
     }
 
-    public RaygunMessage ExposeBuildMessage(Exception exception, [Optional] IList<string> tags, [Optional] IDictionary userCustomData)
+    public RaygunMessage ExposeBuildMessage(Exception exception, [Optional] IList<string> tags, [Optional] IDictionary userCustomData, [Optional] RaygunIdentifierMessage userIdentifierMessage)
     {
-      return BuildMessage(exception, tags, userCustomData);
+      return BuildMessage(exception, tags, userCustomData, userIdentifierMessage);
     }
 
     public bool ExposeValidateApiKey()

--- a/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
@@ -89,6 +89,26 @@ namespace Mindscape.Raygun4Net.Tests
     }
 
     [Test]
+    public void MessageWithUserInfoFromBuild()
+    {
+        RaygunMessage message = _client.ExposeBuildMessage(_exception, null, null, new RaygunIdentifierMessage("Robbie Robot"));
+        Assert.AreEqual("Robbie Robot", message.Details.User.Identifier);
+        Assert.IsFalse(message.Details.User.IsAnonymous);
+    }
+
+    [Test]
+    public void UserInfoFromBuildTrumpsAll()
+    {
+        RaygunIdentifierMessage user = new RaygunIdentifierMessage("Not Robbie Robot") { IsAnonymous = true };
+        _client.UserInfo = user;
+        _client.User = "Also Not Robbie Robot";
+
+        RaygunMessage message = _client.ExposeBuildMessage(_exception, null, null, new RaygunIdentifierMessage("Robbie Robot"));
+        Assert.AreEqual("Robbie Robot", message.Details.User.Identifier);
+        Assert.IsFalse(message.Details.User.IsAnonymous);
+    }
+
+    [Test]
     public void IsAnonymousDefault()
     {
       RaygunIdentifierMessage user = new RaygunIdentifierMessage("Robbie Robot");


### PR DESCRIPTION
Under a multi threaded scenario it's possible that the User/UserInfo on
a reused client could be changed before a SendInBackground operation
completes, leading to a disconnect from the User at the time the
Exception was generated and when the Error Message is built.
