### PR TITLE
Move user info, proxy credentials and application version

### DIFF
--- a/Mindscape.Raygun4Net.WebApi.Tests/Model/FakeRaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/Model/FakeRaygunWebApiClient.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Mindscape.Raygun4Net.Messages;
-using Mindscape.Raygun4Net.WebApi;
+﻿using Mindscape.Raygun4Net.Messages;
 
 namespace Mindscape.Raygun4Net.WebApi.Tests.Model
 {

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -163,27 +163,6 @@ namespace Mindscape.Raygun4Net.WebApi
     }
 
     /// <summary>
-    /// Gets or sets the user identity string.
-    /// </summary>
-    public string User { get; set; }
-
-    /// <summary>
-    /// Gets or sets information about the user including the identity string.
-    /// </summary>
-    public RaygunIdentifierMessage UserInfo { get; set; }
-
-    /// <summary>
-    /// Gets or sets the username/password credentials which are used to authenticate with the system default Proxy server, if one is set
-    /// and requires credentials.
-    /// </summary>
-    public ICredentials ProxyCredentials { get; set; }
-
-    /// <summary>
-    /// Gets or sets a custom application version identifier for all error messages sent to the Raygun.io endpoint.
-    /// </summary>
-    public string ApplicationVersion { get; set; }
-
-    /// <summary>
     /// Adds a list of outer exceptions that will be stripped, leaving only the valuable inner exception.
     /// This can be used when a wrapper exception, e.g. TargetInvocationException or HttpUnhandledException,
     /// contains the actual exception as the InnerException. The message and stack trace of the inner exception will then

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
-using System.Runtime.InteropServices;
 using Mindscape.Raygun4Net.Messages;
 
 using System.Web;
@@ -75,27 +73,6 @@ namespace Mindscape.Raygun4Net
       }
       return true;
     }
-
-    /// <summary>
-    /// Gets or sets the user identity string.
-    /// </summary>
-    public string User { get; set; }
-
-    /// <summary>
-    /// Gets or sets information about the user including the identity string.
-    /// </summary>
-    public RaygunIdentifierMessage UserInfo { get; set; }
-
-    /// <summary>
-    /// Gets or sets the username/password credentials which are used to authenticate with the system default Proxy server, if one is set
-    /// and requires credentials.
-    /// </summary>
-    public ICredentials ProxyCredentials { get; set; }
-
-    /// <summary>
-    /// Gets or sets a custom application version identifier for all error messages sent to the Raygun.io endpoint.
-    /// </summary>
-    public string ApplicationVersion { get; set; }
 
     /// <summary>
     /// Adds a list of outer exceptions that will be stripped, leaving only the valuable inner exception.

--- a/Mindscape.Raygun4Net/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net/RaygunClientBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using Mindscape.Raygun4Net.Messages;
 
 namespace Mindscape.Raygun4Net
@@ -6,6 +7,27 @@ namespace Mindscape.Raygun4Net
   public abstract class RaygunClientBase
   {
     protected internal const string SentKey = "AlreadySentByRaygun";
+
+    /// <summary>
+    /// Gets or sets the user identity string.
+    /// </summary>
+    public string User { get; set; }
+
+    /// <summary>
+    /// Gets or sets information about the user including the identity string.
+    /// </summary>
+    public RaygunIdentifierMessage UserInfo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the username/password credentials which are used to authenticate with the system default Proxy server, if one is set
+    /// and requires credentials.
+    /// </summary>
+    public ICredentials ProxyCredentials { get; set; }
+
+    /// <summary>
+    /// Gets or sets a custom application version identifier for all error messages sent to the Raygun.io endpoint.
+    /// </summary>
+    public string ApplicationVersion { get; set; }
 
     protected bool CanSend(Exception exception)
     {


### PR DESCRIPTION
Move user info, proxy credentials and application version into RaygunClientBase. This lets us use one method to set those properties on standard, web api and mvc RaygunClient objects as they all implement that class. Like this:

``` csharp

public static RaygunWebApiClient GetWebApiRaygunClient()
{
  return (RaygunWebApiClient) AddVersionToRaygunClient(AddUserToRaygunClient(new RaygunWebApiClient()));
}

public static RaygunClient GetRaygunClient()
{
  return (RaygunClient) AddVersionToRaygunClient(AddUserToRaygunClient(new RaygunClient()));
}
```
