### PR TITLE
Extracted WebClient creation into a separate method so that it could be tested a wee bit...

### DIFF
--- a/Mindscape.Raygun4Net.Tests/Mindscape.Raygun4Net.Tests.csproj
+++ b/Mindscape.Raygun4Net.Tests/Mindscape.Raygun4Net.Tests.csproj
@@ -71,6 +71,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
 using Mindscape.Raygun4Net.Messages;
@@ -20,6 +21,11 @@ namespace Mindscape.Raygun4Net.Tests
     public RaygunMessage ExposeBuildMessage(Exception exception, [Optional] IList<string> tags, [Optional] IDictionary userCustomData)
     {
       return BuildMessage(exception, tags, userCustomData);
+    }
+
+    public WebClient ExposeWebClient()
+    {
+      return CreateWebClient();
     }
 
     public bool ExposeValidateApiKey()

--- a/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Web;
 using Mindscape.Raygun4Net.Messages;
 using NUnit.Framework;
@@ -29,9 +31,37 @@ namespace Mindscape.Raygun4Net.Tests
     }
 
     [Test]
+    public void DefaultProxyCredentials()
+    {
+      Assert.IsNull(_client.ProxyCredentials);
+    }
+
+    [Test]
+    public void DefaultWebProxy()
+    {
+      Assert.IsNull(_client.UserInfo);
+    }
+
+    [Test]
     public void DefaultUserInfo()
     {
       Assert.IsNull(_client.UserInfo);
+    }
+
+    [Test]
+    public void ProxyCredentials()
+    {
+      var credentials = new NetworkCredential();
+      _client.ProxyCredentials = credentials;
+      Assert.AreSame(credentials, _client.ProxyCredentials);
+    }
+
+    [Test]
+    public void WebProxy()
+    {
+      var proxy = new WebProxy();
+      _client.WebProxy = proxy;
+      Assert.AreSame(proxy, _client.WebProxy);
     }
 
     [Test]
@@ -388,6 +418,21 @@ namespace Mindscape.Raygun4Net.Tests
     public void FlagNullAsSent()
     {
       Assert.DoesNotThrow(() => { _client.ExposeFlagAsSent(null); });
+    }
+
+    // WebProxy creation tests
+    [Test]
+    public void WebProxyPropertyPreferredOverDefaultWebProxy()
+    {
+      var theProxyWeDontWant = new WebProxy();
+      var theProxyWeDoWant = new WebProxy();
+
+      WebRequest.DefaultWebProxy = theProxyWeDontWant;
+      _client.WebProxy = theProxyWeDoWant;
+
+      var webClient = _client.ExposeWebClient();
+
+      Assert.AreSame(theProxyWeDoWant, webClient.Proxy);
     }
   }
 }


### PR DESCRIPTION
... and then gave the client the ability to set their own IWebProxy instance.  

I know this team [wink wink] that needs this functionality.  They need to set the WebProxy conditionally, only for contacting certain external services such as Raygun, based on a URI stored in an application configuration file, however setting the WebRequest.DefaultWebProxy (which I think has a scope that spans the current AppDomain) just for Raygun causes problems elsewhere in the system, when making separate calls to other systems for which the WebProxy is not used and needs to be avoided.

This change might obviate the previously existing code in the RaygunClient.CreateWebClient() "else if" branch, but I have not been able to fully deduce the intent behind the WebRequest.DefaultWebProxy.GetProxy() call, and so this decision should be pointed out to, but left to the discretion of the reviewer.  

Thank you!
