### PR TITLE
Improve appversion configuration

### DIFF
--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -57,6 +57,10 @@ namespace Mindscape.Raygun4Net.WebApi
         var ignoredNames = RaygunSettings.Settings.IgnoreServerVariableNames.Split(',');
         IgnoreServerVariableNames(ignoredNames);
       }
+      if (!string.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        ApplicationVersion = RaygunSettings.Settings.ApplicationVersion;
+      }
       IsRawDataIgnored = RaygunSettings.Settings.IsRawDataIgnored;
     }
 
@@ -78,8 +82,16 @@ namespace Mindscape.Raygun4Net.WebApi
     {
       Detach(config);
 
-      var entryAssembly = Assembly.GetCallingAssembly();
-      string applicationVersion = entryAssembly.GetName().Version.ToString();
+      string applicationVersion;
+      if (!string.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        applicationVersion = RaygunSettings.Settings.ApplicationVersion;
+      }
+      else
+      {
+        var entryAssembly = Assembly.GetCallingAssembly();
+        applicationVersion = entryAssembly.GetName().Version.ToString();
+      }     
 
       config.MessageHandlers.Add(new RaygunWebApiDelegatingHandler());
 

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiMessageBuilder.cs
@@ -122,6 +122,10 @@ namespace Mindscape.Raygun4Net.WebApi
       if (!String.IsNullOrEmpty(version))
       {
         _raygunMessage.Details.Version = version;
+      }	  
+      else if (!String.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        _raygunMessage.Details.Version = RaygunSettings.Settings.ApplicationVersion;
       }
       else
       {

--- a/Mindscape.Raygun4Net/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net/RaygunClientBase.cs
@@ -18,10 +18,21 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     public virtual RaygunIdentifierMessage UserInfo { get; set; }
 
+    private string applicationVersion;
     /// <summary>
     /// Gets or sets a custom application version identifier for all error messages sent to the Raygun.io endpoint.
     /// </summary>
-    public string ApplicationVersion { get; set; }
+    public string ApplicationVersion
+    {
+        get
+        {
+            return this.applicationVersion;
+        }
+        set
+        {
+            this.applicationVersion = value;
+        }
+    }
 
     protected bool CanSend(Exception exception)
     {

--- a/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
@@ -144,6 +144,10 @@ namespace Mindscape.Raygun4Net
       {
         _raygunMessage.Details.Version = version;
       }
+      else if (!String.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        _raygunMessage.Details.Version = RaygunSettings.Settings.ApplicationVersion;
+      }
       else
       {
         var entryAssembly = Assembly.GetEntryAssembly();

--- a/Mindscape.Raygun4Net/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net/RaygunSettings.cs
@@ -99,6 +99,13 @@ namespace Mindscape.Raygun4Net
       set { this["isRawDataIgnored"] = value; }
     }
 
+    [ConfigurationProperty("applicationVersion", IsRequired = false, DefaultValue = "")]
+    public string ApplicationVersion
+    {
+        get { return (string)this["applicationVersion"]; }
+        set { this["applicationVersion"] = value; }
+    }
+
     /// <summary>
     /// Return false.
     /// </summary>

--- a/Mindscape.Raygun4Net2/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net2/RaygunMessageBuilder.cs
@@ -139,6 +139,10 @@ namespace Mindscape.Raygun4Net
       if (!String.IsNullOrEmpty(version))
       {
         _raygunMessage.Details.Version = version;
+      }	  
+      else if (!String.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        _raygunMessage.Details.Version = RaygunSettings.Settings.ApplicationVersion;
       }
       else
       {

--- a/Mindscape.Raygun4Net2/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net2/RaygunSettings.cs
@@ -78,5 +78,12 @@ namespace Mindscape.Raygun4Net
       get { return (bool)this["isRawDataIgnored"]; }
       set { this["isRawDataIgnored"] = value; }
     }
+
+    [ConfigurationProperty("applicationVersion", IsRequired = false, DefaultValue = "")]
+    public string ApplicationVersion
+    {
+        get { return (string)this["applicationVersion"]; }
+        set { this["applicationVersion"] = value; }
+    }
   }
 }

--- a/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
+++ b/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2CF1FE1F-AD2D-40BD-9F99-57FF00445A9D}</ProjectGuid>
+    <ProjectGuid>{6D1C7E96-5E04-421D-8E8A-B3C8C02FD41D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mindscape.Raygun4Net</RootNamespace>


### PR DESCRIPTION
Now, it is possible to set the ApplicationVersion in the config file or at the initialization of the application

```
protected void Application_Start()
{
    var applicationVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();

    Mindscape.Raygun4Net.RaygunSettings.Settings.ApplicationVersion = applicationVersion;

    ...
}
```

i havent done any work in the following projects since that i don't have the libraries to test them:
- WindowsPhone
- WindowsStore
- WinRT
- Xamarin.*

I had to make a little hack to the WebApi project since that the initialization of the ApplicationVersion is not the same as the other projects.