### PR TITLE
Improve request header

### DIFF
--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -420,7 +420,7 @@ namespace Mindscape.Raygun4Net.WebApi
           using (var client = new WebClient())
           {
             client.Headers.Add("X-ApiKey", _apiKey);
-			client.Headers.Add("content-type", "application/json; charset=utf-8");
+            client.Headers.Add("content-type", "application/json; charset=utf-8");
             client.Encoding = System.Text.Encoding.UTF8;
 
             if (WebRequest.DefaultWebProxy != null)

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -57,6 +57,10 @@ namespace Mindscape.Raygun4Net.WebApi
         var ignoredNames = RaygunSettings.Settings.IgnoreServerVariableNames.Split(',');
         IgnoreServerVariableNames(ignoredNames);
       }
+      if (!string.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        ApplicationVersion = RaygunSettings.Settings.ApplicationVersion;
+      }
       IsRawDataIgnored = RaygunSettings.Settings.IsRawDataIgnored;
     }
 
@@ -78,8 +82,16 @@ namespace Mindscape.Raygun4Net.WebApi
     {
       Detach(config);
 
-      var entryAssembly = Assembly.GetCallingAssembly();
-      string applicationVersion = entryAssembly.GetName().Version.ToString();
+      string applicationVersion;
+      if (!string.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        applicationVersion = RaygunSettings.Settings.ApplicationVersion;
+      }
+      else
+      {
+        var entryAssembly = Assembly.GetCallingAssembly();
+        applicationVersion = entryAssembly.GetName().Version.ToString();
+      }     
 
       config.MessageHandlers.Add(new RaygunWebApiDelegatingHandler());
 

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -420,6 +420,7 @@ namespace Mindscape.Raygun4Net.WebApi
           using (var client = new WebClient())
           {
             client.Headers.Add("X-ApiKey", _apiKey);
+			client.Headers.Add("content-type", "application/json; charset=utf-8");
             client.Encoding = System.Text.Encoding.UTF8;
 
             if (WebRequest.DefaultWebProxy != null)

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiMessageBuilder.cs
@@ -122,6 +122,10 @@ namespace Mindscape.Raygun4Net.WebApi
       if (!String.IsNullOrEmpty(version))
       {
         _raygunMessage.Details.Version = version;
+      }	  
+      else if (!String.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        _raygunMessage.Details.Version = RaygunSettings.Settings.ApplicationVersion;
       }
       else
       {

--- a/Mindscape.Raygun4Net.Xamarin.Android/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Android/RaygunClient.cs
@@ -311,6 +311,7 @@ namespace Mindscape.Raygun4Net
             using (var client = new WebClient())
             {
               client.Headers.Add("X-ApiKey", _apiKey);
+			  client.Headers.Add("content-type", "application/json; charset=utf-8");
               client.Encoding = System.Text.Encoding.UTF8;
 
               try
@@ -355,6 +356,7 @@ namespace Mindscape.Raygun4Net
       using (var client = new WebClient())
       {
         client.Headers.Add("X-ApiKey", _apiKey);
+		client.Headers.Add("content-type", "application/json; charset=utf-8");
         client.Encoding = System.Text.Encoding.UTF8;
 
         try

--- a/Mindscape.Raygun4Net.Xamarin.Android/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Android/RaygunClient.cs
@@ -311,7 +311,7 @@ namespace Mindscape.Raygun4Net
             using (var client = new WebClient())
             {
               client.Headers.Add("X-ApiKey", _apiKey);
-			  client.Headers.Add("content-type", "application/json; charset=utf-8");
+              client.Headers.Add("content-type", "application/json; charset=utf-8");
               client.Encoding = System.Text.Encoding.UTF8;
 
               try

--- a/Mindscape.Raygun4Net.Xamarin.Android/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Android/RaygunClient.cs
@@ -356,7 +356,7 @@ namespace Mindscape.Raygun4Net
       using (var client = new WebClient())
       {
         client.Headers.Add("X-ApiKey", _apiKey);
-		client.Headers.Add("content-type", "application/json; charset=utf-8");
+        client.Headers.Add("content-type", "application/json; charset=utf-8");
         client.Encoding = System.Text.Encoding.UTF8;
 
         try

--- a/Mindscape.Raygun4Net.Xamarin.Mac/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Mac/RaygunClient.cs
@@ -290,7 +290,7 @@ namespace Mindscape.Raygun4Net
             using (var client = new WebClient())
             {
               client.Headers.Add("X-ApiKey", _apiKey);
-			  client.Headers.Add("content-type", "application/json; charset=utf-8");
+              client.Headers.Add("content-type", "application/json; charset=utf-8");
               client.Encoding = System.Text.Encoding.UTF8;
 
               try

--- a/Mindscape.Raygun4Net.Xamarin.Mac/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Mac/RaygunClient.cs
@@ -290,6 +290,7 @@ namespace Mindscape.Raygun4Net
             using (var client = new WebClient())
             {
               client.Headers.Add("X-ApiKey", _apiKey);
+			  client.Headers.Add("content-type", "application/json; charset=utf-8");
               client.Encoding = System.Text.Encoding.UTF8;
 
               try

--- a/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClient.cs
@@ -540,6 +540,7 @@ namespace Mindscape.Raygun4Net
       using (var client = new WebClient())
       {
         client.Headers.Add("X-ApiKey", _apiKey);
+		client.Headers.Add("content-type", "application/json; charset=utf-8");
         client.Encoding = System.Text.Encoding.UTF8;
 
         try

--- a/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClient.cs
@@ -540,7 +540,7 @@ namespace Mindscape.Raygun4Net
       using (var client = new WebClient())
       {
         client.Headers.Add("X-ApiKey", _apiKey);
-		client.Headers.Add("content-type", "application/json; charset=utf-8");
+        client.Headers.Add("content-type", "application/json; charset=utf-8");
         client.Encoding = System.Text.Encoding.UTF8;
 
         try

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -398,6 +398,7 @@ namespace Mindscape.Raygun4Net
     {
       var client = new WebClient();
       client.Headers.Add("X-ApiKey", _apiKey);
+	  client.Headers.Add("content-type", "application/json; charset=utf-8");
       client.Encoding = System.Text.Encoding.UTF8;
 
       if (WebProxy != null)

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -398,7 +398,7 @@ namespace Mindscape.Raygun4Net
     {
       var client = new WebClient();
       client.Headers.Add("X-ApiKey", _apiKey);
-	  client.Headers.Add("content-type", "application/json; charset=utf-8");
+      client.Headers.Add("content-type", "application/json; charset=utf-8");
       client.Encoding = System.Text.Encoding.UTF8;
 
       if (WebProxy != null)

--- a/Mindscape.Raygun4Net/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net/RaygunClientBase.cs
@@ -18,10 +18,21 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     public virtual RaygunIdentifierMessage UserInfo { get; set; }
 
+    private string applicationVersion;
     /// <summary>
     /// Gets or sets a custom application version identifier for all error messages sent to the Raygun.io endpoint.
     /// </summary>
-    public string ApplicationVersion { get; set; }
+    public string ApplicationVersion
+    {
+        get
+        {
+            return this.applicationVersion;
+        }
+        set
+        {
+            this.applicationVersion = value;
+        }
+    }
 
     protected bool CanSend(Exception exception)
     {

--- a/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net/RaygunMessageBuilder.cs
@@ -144,6 +144,10 @@ namespace Mindscape.Raygun4Net
       {
         _raygunMessage.Details.Version = version;
       }
+      else if (!String.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        _raygunMessage.Details.Version = RaygunSettings.Settings.ApplicationVersion;
+      }
       else
       {
         var entryAssembly = Assembly.GetEntryAssembly();

--- a/Mindscape.Raygun4Net/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net/RaygunSettings.cs
@@ -99,6 +99,13 @@ namespace Mindscape.Raygun4Net
       set { this["isRawDataIgnored"] = value; }
     }
 
+    [ConfigurationProperty("applicationVersion", IsRequired = false, DefaultValue = "")]
+    public string ApplicationVersion
+    {
+        get { return (string)this["applicationVersion"]; }
+        set { this["applicationVersion"] = value; }
+    }
+
     /// <summary>
     /// Return false.
     /// </summary>

--- a/Mindscape.Raygun4Net2/RaygunClient.cs
+++ b/Mindscape.Raygun4Net2/RaygunClient.cs
@@ -328,6 +328,7 @@ namespace Mindscape.Raygun4Net
       using (var client = new WebClient())
       {
         client.Headers.Add("X-ApiKey", _apiKey);
+		client.Headers.Add("content-type", "application/json; charset=utf-8");
         client.Encoding = System.Text.Encoding.UTF8;
 
         try

--- a/Mindscape.Raygun4Net2/RaygunClient.cs
+++ b/Mindscape.Raygun4Net2/RaygunClient.cs
@@ -328,7 +328,7 @@ namespace Mindscape.Raygun4Net
       using (var client = new WebClient())
       {
         client.Headers.Add("X-ApiKey", _apiKey);
-		client.Headers.Add("content-type", "application/json; charset=utf-8");
+        client.Headers.Add("content-type", "application/json; charset=utf-8");
         client.Encoding = System.Text.Encoding.UTF8;
 
         try

--- a/Mindscape.Raygun4Net2/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net2/RaygunMessageBuilder.cs
@@ -139,6 +139,10 @@ namespace Mindscape.Raygun4Net
       if (!String.IsNullOrEmpty(version))
       {
         _raygunMessage.Details.Version = version;
+      }	  
+      else if (!String.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        _raygunMessage.Details.Version = RaygunSettings.Settings.ApplicationVersion;
       }
       else
       {

--- a/Mindscape.Raygun4Net2/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net2/RaygunSettings.cs
@@ -78,5 +78,12 @@ namespace Mindscape.Raygun4Net
       get { return (bool)this["isRawDataIgnored"]; }
       set { this["isRawDataIgnored"] = value; }
     }
+
+    [ConfigurationProperty("applicationVersion", IsRequired = false, DefaultValue = "")]
+    public string ApplicationVersion
+    {
+        get { return (string)this["applicationVersion"]; }
+        set { this["applicationVersion"] = value; }
+    }
   }
 }

--- a/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
+++ b/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2CF1FE1F-AD2D-40BD-9F99-57FF00445A9D}</ProjectGuid>
+    <ProjectGuid>{6D1C7E96-5E04-421D-8E8A-B3C8C02FD41D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mindscape.Raygun4Net</RootNamespace>

--- a/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
+++ b/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6D1C7E96-5E04-421D-8E8A-B3C8C02FD41D}</ProjectGuid>
+    <ProjectGuid>{2CF1FE1F-AD2D-40BD-9F99-57FF00445A9D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mindscape.Raygun4Net</RootNamespace>


### PR DESCRIPTION
Since that Raygun client sends json data to his service, the request should include the Content-Type header set to "application/json; charset=uff-8".

The only clients that i havent done this change are the WindowsPhone and the WinRT clients. They had already the content-type setted but with the value "application/x-raygun-message".