### PR TITLE
Fixes #232 - ArgumentNullException thrown by Identify(string userId)

### DIFF
--- a/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClient.cs
@@ -353,9 +353,11 @@ namespace Mindscape.Raygun4Net
       }
 
       _client.User = user; // Set this last so that it can be passed to the native reporter.
-      if (user == null && _client._reporter != null)
+	  
+      string deviceId = _client.DeviceId;	  
+      if (user == null && _client._reporter != null && !String.IsNullOrWhiteSpace(deviceId))
       {
-        _client._reporter.Identify(_client.DeviceId);
+        _client._reporter.Identify(deviceId);
       }
     }
 


### PR DESCRIPTION
Fix based on existing check for `DeviceId` in `BuildRaygunIdentifierMessage()`.

https://github.com/MindscapeHQ/raygun4net/blob/v4.2.0/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClient.cs#L474