### PR TITLE
Add HttpRequestMessage to the generateRaygunClient function

### DIFF
--- a/Mindscape.Raygun4Net.WebApi/IRaygunWebApiClientProvider.cs
+++ b/Mindscape.Raygun4Net.WebApi/IRaygunWebApiClientProvider.cs
@@ -1,35 +1,40 @@
 ﻿using System;
+using System.Net.Http;
 
 namespace Mindscape.Raygun4Net.WebApi
 {
   internal interface IRaygunWebApiClientProvider
   {
-    RaygunWebApiClient GenerateRaygunWebApiClient();
+    RaygunWebApiClient GenerateRaygunWebApiClient(HttpRequestMessage currentRequest = null);
   }
 
   internal class RaygunWebApiClientProvider : IRaygunWebApiClientProvider
   {
-    private readonly Func<RaygunWebApiClient> _generateRaygunClient;
+    private readonly Func<HttpRequestMessage, RaygunWebApiClient> _generateRaygunClient;
     private readonly string _applicationVersionFromAttach;
 
-    public RaygunWebApiClientProvider(Func<RaygunWebApiClient> generateRaygunClient = null, string applicationVersionFromAttach = null)
+    public RaygunWebApiClientProvider(Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClientWithHttpRequest,
+      string applicationVersionFromAttach)
     {
-      _generateRaygunClient = generateRaygunClient;
+      _generateRaygunClient = generateRaygunClientWithHttpRequest;
+
       _applicationVersionFromAttach = applicationVersionFromAttach;
     }
 
-    public RaygunWebApiClient GenerateRaygunWebApiClient()
+    public RaygunWebApiClient GenerateRaygunWebApiClient(HttpRequestMessage currentRequest = null)
     {
       if (_generateRaygunClient == null)
       {
         return new RaygunWebApiClient { ApplicationVersion = _applicationVersionFromAttach };
       }
 
-      var client = _generateRaygunClient();
+      var client = _generateRaygunClient(currentRequest);
       if(client.ApplicationVersion == null)
       {
         client.ApplicationVersion = _applicationVersionFromAttach;
       }
+      client.CurrentHttpRequest(currentRequest);
+
       return client;
     }
   }

--- a/Mindscape.Raygun4Net.WebApi/IRaygunWebApiClientProvider.cs
+++ b/Mindscape.Raygun4Net.WebApi/IRaygunWebApiClientProvider.cs
@@ -23,17 +23,25 @@ namespace Mindscape.Raygun4Net.WebApi
 
     public RaygunWebApiClient GenerateRaygunWebApiClient(HttpRequestMessage currentRequest = null)
     {
+      RaygunWebApiClient client = null;
+
       if (_generateRaygunClient == null)
       {
-        return new RaygunWebApiClient { ApplicationVersion = _applicationVersionFromAttach };
+        client = new RaygunWebApiClient();
+      }
+      else
+      {
+        client = _generateRaygunClient(currentRequest);
       }
 
-      var client = _generateRaygunClient(currentRequest);
-      if(client.ApplicationVersion == null)
+      if (client != null)
       {
-        client.ApplicationVersion = _applicationVersionFromAttach;
+        if (client.ApplicationVersion == null)
+        {
+          client.ApplicationVersion = _applicationVersionFromAttach;
+        }
+        client.CurrentHttpRequest(currentRequest);
       }
-      client.CurrentHttpRequest(currentRequest);
 
       return client;
     }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -79,7 +79,9 @@ namespace Mindscape.Raygun4Net.WebApi
     /// <param name="config">The HttpConfiguration to attach to.</param>
     public static void Attach(HttpConfiguration config)
     {
-      AttachInternal(config);
+      var entryAssembly = Assembly.GetCallingAssembly();
+      string version = entryAssembly.GetName().Version.ToString();
+      AttachInternal(config, null, version);
     }
 
     /// <summary>
@@ -90,13 +92,15 @@ namespace Mindscape.Raygun4Net.WebApi
     [Obsolete("Use Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient = null) instead")]
     public static void Attach(HttpConfiguration config, Func<RaygunWebApiClient> generateRaygunClient)
     {
+      var entryAssembly = Assembly.GetCallingAssembly();
+      string version = entryAssembly.GetName().Version.ToString();
       if (generateRaygunClient != null)
       {
-        AttachInternal(config, message => generateRaygunClient());
+        AttachInternal(config, message => generateRaygunClient(), version);
       }
       else
       {
-        AttachInternal(config);
+        AttachInternal(config, null, version);
       }
     }
 
@@ -111,10 +115,12 @@ namespace Mindscape.Raygun4Net.WebApi
     /// </param>
     public static void Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient)
     {
-      AttachInternal(config, generateRaygunClient);
+      var entryAssembly = Assembly.GetCallingAssembly();
+      string version = entryAssembly.GetName().Version.ToString();
+      AttachInternal(config, generateRaygunClient, version);
     }
 
-    private static void AttachInternal(HttpConfiguration config, Func<HttpRequestMessage,RaygunWebApiClient> generateRaygunClientWithMessage = null)
+    private static void AttachInternal(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClientWithMessage, string applicationVersionFromAttach)
     {
       Detach(config);
 
@@ -125,8 +131,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       else
       {
-        var entryAssembly = Assembly.GetCallingAssembly();
-        applicationVersion = entryAssembly.GetName().Version.ToString();
+        applicationVersion = applicationVersionFromAttach;
       }
 
       var owinAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName.StartsWith("Owin"));

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -89,7 +89,6 @@ namespace Mindscape.Raygun4Net.WebApi
     /// </summary>
     /// <param name="config">The HttpConfiguration to attach to.</param>
     /// <param name="generateRaygunClient">An optional function to provide a custom RaygunWebApiClient instance to use for reporting exceptions.</param>
-    [Obsolete("Use Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient = null) instead")]
     public static void Attach(HttpConfiguration config, Func<RaygunWebApiClient> generateRaygunClient)
     {
       var entryAssembly = Assembly.GetCallingAssembly();

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -73,6 +73,10 @@ namespace Mindscape.Raygun4Net.WebApi
     {
     }
 
+    /// <summary>
+    /// Causes Raygun4Net to listen for exceptions.
+    /// </summary>
+    /// <param name="config">The HttpConfiguration to attach to.</param>
     public static void Attach(HttpConfiguration config)
     {
       AttachInternal(config);

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -73,13 +73,18 @@ namespace Mindscape.Raygun4Net.WebApi
     {
     }
 
+    public static void Attach(HttpConfiguration config)
+    {
+      AttachInternal(config);
+    }
+
     /// <summary>
     /// Causes Raygun4Net to listen for exceptions.
     /// </summary>
     /// <param name="config">The HttpConfiguration to attach to.</param>
     /// <param name="generateRaygunClient">An optional function to provide a custom RaygunWebApiClient instance to use for reporting exceptions.</param>
     [Obsolete("Use Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient = null) instead")]
-    public static void Attach(HttpConfiguration config, Func<RaygunWebApiClient> generateRaygunClient = null)
+    public static void Attach(HttpConfiguration config, Func<RaygunWebApiClient> generateRaygunClient)
     {
       if (generateRaygunClient != null)
       {
@@ -100,7 +105,7 @@ namespace Mindscape.Raygun4Net.WebApi
     /// The HttpRequestMessage parameter to this function might be null if there is no request in the context of the
     /// failure we are currently handling.
     /// </param>
-    public static void Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient = null)
+    public static void Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient)
     {
       AttachInternal(config, generateRaygunClient);
     }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -78,7 +78,34 @@ namespace Mindscape.Raygun4Net.WebApi
     /// </summary>
     /// <param name="config">The HttpConfiguration to attach to.</param>
     /// <param name="generateRaygunClient">An optional function to provide a custom RaygunWebApiClient instance to use for reporting exceptions.</param>
+    [Obsolete("Use Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient = null) instead")]
     public static void Attach(HttpConfiguration config, Func<RaygunWebApiClient> generateRaygunClient = null)
+    {
+      if (generateRaygunClient != null)
+      {
+        AttachInternal(config, message => generateRaygunClient());
+      }
+      else
+      {
+        AttachInternal(config);
+      }
+    }
+
+    /// <summary>
+    /// Causes Raygun4Net to listen for exceptions.
+    /// </summary>
+    /// <param name="config">The HttpConfiguration to attach to.</param>
+    /// <param name="generateRaygunClient">
+    /// An optional function to provide a custom RaygunWebApiClient instance to use for reporting exceptions.
+    /// The HttpRequestMessage parameter to this function might be null if there is no request in the context of the
+    /// failure we are currently handling.
+    /// </param>
+    public static void Attach(HttpConfiguration config, Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClient = null)
+    {
+      AttachInternal(config, generateRaygunClient);
+    }
+
+    private static void AttachInternal(HttpConfiguration config, Func<HttpRequestMessage,RaygunWebApiClient> generateRaygunClientWithMessage = null)
     {
       Detach(config);
 
@@ -99,7 +126,7 @@ namespace Mindscape.Raygun4Net.WebApi
         config.MessageHandlers.Add(new RaygunWebApiDelegatingHandler());
       }
 
-      var clientCreator = new RaygunWebApiClientProvider(generateRaygunClient, applicationVersion);
+      var clientCreator = new RaygunWebApiClientProvider(generateRaygunClientWithMessage, applicationVersion);
 
       config.Services.Add(typeof(IExceptionLogger), new RaygunWebApiExceptionLogger(clientCreator));
 

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiControllerActivator.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiControllerActivator.cs
@@ -24,14 +24,14 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch(InvalidOperationException ex)
       {
-        var client = _clientCreator.GenerateRaygunWebApiClient();
-        client.CurrentHttpRequest(request).SendInBackground(ex.InnerException);
+        var client = _clientCreator.GenerateRaygunWebApiClient(request);
+        client.SendInBackground(ex.InnerException);
         client.FlagExceptionAsSent(ex); // Stops us re-sending the outer exception
         throw;
       }
       catch(Exception ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(request).SendInBackground(ex);
+        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex);
         throw;
       }
     }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiExceptionLogger.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiExceptionLogger.cs
@@ -15,14 +15,13 @@ namespace Mindscape.Raygun4Net.WebApi
 
     public override void Log(ExceptionLoggerContext context)
     {
-      _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(context.Request).SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
     }
 
 #pragma warning disable 1998
     public override async Task LogAsync(ExceptionLoggerContext context, CancellationToken cancellationToken)
     {
-        _clientCreator.GenerateRaygunWebApiClient()
-            .CurrentHttpRequest(context.Request)
+      _clientCreator.GenerateRaygunWebApiClient(context.Request)
             .SendInBackground(context.Exception);
     }
 #pragma warning restore 1998

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiExceptionLogger.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiExceptionLogger.cs
@@ -21,8 +21,7 @@ namespace Mindscape.Raygun4Net.WebApi
 #pragma warning disable 1998
     public override async Task LogAsync(ExceptionLoggerContext context, CancellationToken cancellationToken)
     {
-      _clientCreator.GenerateRaygunWebApiClient(context.Request)
-            .SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
     }
 #pragma warning restore 1998
   }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiFilters.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiFilters.cs
@@ -18,13 +18,13 @@ namespace Mindscape.Raygun4Net.WebApi
 
     public override void OnException(HttpActionExecutedContext context)
     {
-      _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(context.Request).SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
     }
 
 #pragma warning disable 1998
     public override async Task OnExceptionAsync(HttpActionExecutedContext context, CancellationToken cancellationToken)
     {
-      _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(context.Request).SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
     }
 #pragma warning restore 1998
   }
@@ -50,7 +50,7 @@ namespace Mindscape.Raygun4Net.WebApi
           context.Response.ReasonPhrase,
           string.Format("HTTP {0} returned while handling Request {2} {1}", (int)context.Response.StatusCode, context.Request.RequestUri, context.Request.Method));
 
-        _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(context.Request).SendInBackground(e);
+        _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(e);
       }
     }
   }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiSelectors.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiSelectors.cs
@@ -24,7 +24,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch (HttpResponseException ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(controllerContext.Request).SendInBackground(ex);
+        _clientCreator.GenerateRaygunWebApiClient(controllerContext.Request).SendInBackground(ex);
         throw;
       }
     }
@@ -59,7 +59,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch (HttpResponseException ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient().CurrentHttpRequest(request).SendInBackground(ex);
+        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex);
         throw;
       }
     }


### PR DESCRIPTION
Add HttpRequestMessage to the generateRaygunClient function used to instatiate a custom RaygunWebApiClient. This lets people use the current Http Request info when constructing a client.

Deprecate the old Attach method which takes Func&lt;RaygunWebApiClient&gt; in favour of the one that takes Func&lt;HttpRequestMessage, RaygunWebApiClient&gt;

Probably needs a full version rev as it adds an Obsolete attribute to Attach, although existing clients shouldn't need to actually change anything unless they have warnings as errors turned on.