### PR TITLE
Use InnerException not GetBaseException

### DIFF
--- a/Mindscape.Raygun4Net/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net/RaygunHttpModule.cs
@@ -78,7 +78,7 @@ namespace Mindscape.Raygun4Net
     {
       if (exception is HttpUnhandledException)
       {
-        return exception.GetBaseException();
+        return exception.InnerException;
       }
 
       return exception;


### PR DESCRIPTION
GetBaseException can send you too far down the rabbit hole. For example in a SQL Timeout exception the BaseException is a useless "[Win32Exception: The wait operation timed out]" without a stack trace as it was captured and wrapped by SqlClient. All we want to do here is remove the outermost HttpUnhandledException wrapper