### PR TITLE
Changes Client name to Raygun4Net

### DIFF
--- a/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Messages/RaygunClientMessage.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Messages/RaygunClientMessage.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace Mindscape.Raygun4Net.Messages
+{
+  public class RaygunClientMessage
+  {
+    public RaygunClientMessage()
+    {
+      Name = "Raygun4Net";
+      Version = new AssemblyName(GetType().Assembly.FullName).Version.ToString();
+      ClientUrl = @"https://github.com/MindscapeHQ/raygun4net";
+    }
+
+    public string Name { get; set; }
+
+    public string Version { get; set; }
+
+    public string ClientUrl { get; set; }
+
+    public override string ToString()
+    {
+      // This exists because Reflection in Xamarin can't seem to obtain the Getter methods unless the getter is used somewhere in the code.
+      // The getter of all properties is required to serialize the Raygun messages to JSON.
+      return string.Format("[RaygunClientMessage: Name={0}, Version={1}, ClientUrl={2}]", Name, Version, ClientUrl);
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Mindscape.Raygun4Net.Xamarin.iOS.Unified.csproj
+++ b/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Mindscape.Raygun4Net.Xamarin.iOS.Unified.csproj
@@ -9,8 +9,6 @@
     <RootNamespace>Mindscape.Raygun4Net.Xamarin.iOS.Unified</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Mindscape.Raygun4Net.Xamarin.iOS.Unified</AssemblyName>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -128,9 +126,6 @@
     <Compile Include="..\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
-    <Compile Include="..\Mindscape.Raygun4Net\Messages\RaygunClientMessage.cs">
-      <Link>Messages\RaygunClientMessage.cs</Link>
-    </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\Messages\RaygunErrorStackTraceLineMessage.cs">
       <Link>Messages\RaygunErrorStackTraceLineMessage.cs</Link>
     </Compile>
@@ -173,5 +168,6 @@
     <Compile Include="..\Mindscape.Raygun4Net.Core\Messages\RaygunErrorMessage.cs">
       <Link>Messages\RaygunErrorMessage.cs</Link>
     </Compile>
+    <Compile Include="Messages\RaygunClientMessage.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In order to make Raygun work for Xamarin.iOS the client message is now using ```Raygun4Net``` as client name, since the last one, ```Raygun4Net.Xamarin.iOS.Unified```, was not been reported in the dashboard.

P.S.: I nerver worked with C# before, so sorry if I broke something in your ```csproj``` file :/