### PR TITLE
Made RaygunHttpModule extendable

### DIFF
--- a/Mindscape.Raygun4Net/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net/RaygunHttpModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Web;
@@ -32,7 +33,17 @@ namespace Mindscape.Raygun4Net
     {
     }
 
-    private void SendError(object sender, EventArgs e)
+    protected virtual void SendError(object sender, EventArgs e)
+    {
+      SendErrorInBackground(sender, e);
+    }
+
+    protected virtual void SendError(HttpApplication application, Exception exception)
+    {
+      SendErrorInBackground(application, exception);
+    }
+
+    protected void SendErrorInBackground(object sender, EventArgs e, Dictionary<string, object> customData = null)
     {
       var application = (HttpApplication)sender;
       var lastError = application.Server.GetLastError();
@@ -40,16 +51,16 @@ namespace Mindscape.Raygun4Net
       if (CanSend(lastError))
       {
         var client = GetRaygunClient(application);
-        client.SendInBackground(Unwrap(lastError));
+        client.SendInBackground(Unwrap(lastError), null, customData);
       }
     }
 
-    public void SendError(HttpApplication application, Exception exception)
+    protected virtual void SendErrorInBackground(HttpApplication application, Exception exception, Dictionary<string, object> customData = null)
     {
       if (CanSend(exception))
       {
         var client = GetRaygunClient(application);
-        client.SendInBackground(Unwrap(exception));
+        client.SendInBackground(Unwrap(exception), null, customData);
       }
     }
 


### PR DESCRIPTION
I have been using Raygun for a while, and I liked the way I can just use add the nuget package and have all my MVC errors logged in a centralized location without me having to worry about all the potential points of failure in an application. However, I realised I wanted to add some common custom data to all my error logs, i.e. username and session id. I didn't want to start implementing custom logging all over the place so my first port of call was to try and implement a custom HttpModule for the logging, but when I tried this I saw that the module is not extendable.

To solve this I have simply made the `SendError` methods protected virtual, and have made them call some protected methods `SendErrorInBackground` (these methods contain the original logging logic). The `SendErrorInBackground` methods now take a customData Dictionary parameter, which means it would be very east to implement a custom http module which overrode the `SendError` methods and passed whatever custom data was needed to the new `SendErrorInBackground` and everything would work the same as previously.

I realise there may be reasons for not making this class extendable, but as it is such a small change I thought it would be worth doing it and doing a pull request. If the pull request is not accepted I will just created my own nuget package and run my fork alongside the master branch and periodically merge (although I would prefer not to do this!!).
