### PR TITLE
Use ClickOnce data directory as base if application is network deployed

### DIFF
--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Deployment.Application;
 using System.Linq;
 using System.Net;
 using Mindscape.Raygun4Net.Messages;
@@ -541,7 +542,7 @@ namespace Mindscape.Raygun4Net
     {
       try
       {
-        string path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\RaygunOfflineStorage";
+        string path = OfflineStoragePath;
         if (!Directory.Exists(path))
         {
           Directory.CreateDirectory(path);
@@ -585,13 +586,25 @@ namespace Mindscape.Raygun4Net
 
     private static object _sendLock = new object();
 
+    private string OfflineStoragePath
+    {
+      get
+      {
+        var baseDir = ApplicationDeployment.IsNetworkDeployed ? 
+                    ApplicationDeployment.CurrentDeployment.DataDirectory : 
+                    Environment.GetFolderPath( Environment.SpecialFolder.LocalApplicationData );
+
+        return Path.Combine( baseDir, "RaygunOfflineStorage");
+      }
+    }
+
     private void SendStoredMessages()
     {
       lock (_sendLock)
       {
         try
         {
-          string path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\RaygunOfflineStorage";
+          string path = OfflineStoragePath;
           if (Directory.Exists(path))
           {
             foreach (string name in Directory.EnumerateFiles(path))


### PR DESCRIPTION
This solves the problem having two client applications running on the same machine using Raygun.
When the network dies all messages for all applications using Raygun stores their reports in the
same directory by default. The reports are sent to Raygun at a later point in time, by the first
application to start up with the Raygun client.

This leads to exception reports being sent to the wrong Raygun account and by isolating the
reports stored on the local hard drive we can at least get the right reports into the right
account at Raygun.io.