### PR TITLE
Set HttpContext on client

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.3.1.0")]
-[assembly: AssemblyFileVersion("5.3.1.0")]
+[assembly: AssemblyVersion("5.3.2.0")]
+[assembly: AssemblyFileVersion("5.3.2.0")]

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunAspNetMiddleware.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunAspNetMiddleware.cs
@@ -36,7 +36,7 @@ namespace Mindscape.Raygun4Net
         }
 
         var client = _middlewareSettings.ClientProvider.GetClient(_settings);
-        client.RaygunCurrentRequest(httpContext);
+        client.SetCurrentContext(httpContext);
         await client.SendInBackground(e);
         throw;
       }

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunAspNetMiddleware.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunAspNetMiddleware.cs
@@ -35,8 +35,7 @@ namespace Mindscape.Raygun4Net
           throw;
         }
 
-        var client = _middlewareSettings.ClientProvider.GetClient(_settings);
-        client.SetCurrentContext(httpContext);
+        var client = _middlewareSettings.ClientProvider.GetClient(_settings, httpContext);
         await client.SendInBackground(e);
         throw;
       }

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
@@ -48,7 +48,7 @@ namespace Mindscape.Raygun4Net
     {
     }
 
-    public RaygunClient(RaygunSettings settings)
+    public RaygunClient(RaygunSettings settings, HttpContext context = null)
     {
       _settings = settings;
       _apiKey = settings.ApiKey;
@@ -80,6 +80,11 @@ namespace Mindscape.Raygun4Net
         ApplicationVersion = settings.ApplicationVersion;
       }
       IsRawDataIgnored = settings.IsRawDataIgnored;
+
+      if (context != null)
+      {
+        SetCurrentContext(context);
+      }
     }
 
     /// <summary>

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClientProvider.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClientProvider.cs
@@ -1,16 +1,18 @@
-﻿namespace Mindscape.Raygun4Net
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Mindscape.Raygun4Net
 {
   public interface IRaygunAspNetCoreClientProvider
   {
-    RaygunClient GetClient(RaygunSettings settings);
+    RaygunClient GetClient(RaygunSettings settings, HttpContext context = null);
     RaygunSettings GetRaygunSettings(RaygunSettings baseSettings);
   }
 
   public class DefaultRaygunAspNetCoreClientProvider : IRaygunAspNetCoreClientProvider
   {
-    public virtual RaygunClient GetClient(RaygunSettings settings)
+    public virtual RaygunClient GetClient(RaygunSettings settings, HttpContext context = null)
     {
-      return new RaygunClient(settings);
+      return new RaygunClient(settings, context);
     }
 
     public virtual RaygunSettings GetRaygunSettings(RaygunSettings baseSettings)

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClientProvider.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClientProvider.cs
@@ -4,13 +4,19 @@ namespace Mindscape.Raygun4Net
 {
   public interface IRaygunAspNetCoreClientProvider
   {
-    RaygunClient GetClient(RaygunSettings settings, HttpContext context = null);
+    RaygunClient GetClient(RaygunSettings settings);
+    RaygunClient GetClient(RaygunSettings settings, HttpContext context);
     RaygunSettings GetRaygunSettings(RaygunSettings baseSettings);
   }
 
   public class DefaultRaygunAspNetCoreClientProvider : IRaygunAspNetCoreClientProvider
   {
-    public virtual RaygunClient GetClient(RaygunSettings settings, HttpContext context = null)
+    public virtual RaygunClient GetClient(RaygunSettings settings)
+    {
+      return GetClient(settings, null);
+    }
+
+    public virtual RaygunClient GetClient(RaygunSettings settings, HttpContext context)
     {
       return new RaygunClient(settings, context);
     }

--- a/Mindscape.Raygun4Net.AspNetCore/project.json
+++ b/Mindscape.Raygun4Net.AspNetCore/project.json
@@ -1,6 +1,6 @@
 {
-    "copyright": "Copyright © Raygun 2016",
-    "version": "5.3.1.0",
+    "copyright": "Copyright (c) Raygun 2016",
+    "version": "5.3.2.0",
     "title": "Raygun4Net.AspNetCore",
     "description": "Raygun provider for .NET Core projects",
     "language": "en-US",
@@ -12,7 +12,8 @@
         "repository": {
             "type": "git",
             "url": "https://github.com/MindscapeHQ/raygun4net"
-        }
+        },
+        "files": "readme.txt"
     },
 
     "dependencies": {

--- a/Mindscape.Raygun4Net.AspNetCore/project.json
+++ b/Mindscape.Raygun4Net.AspNetCore/project.json
@@ -8,7 +8,7 @@
         "iconUrl": "https://app.raygun.com/Content/Images/nuget-icon.png",
         "licenseUrl": "https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE",
         "requireLicenseAcceptance": false,
-        "tags": [ "exception", "error" ],
+        "tags": [ "raygun", "error", "tracking", "reporting", "logging", "crash", "exception" ],
         "repository": {
             "type": "git",
             "url": "https://github.com/MindscapeHQ/raygun4net"


### PR DESCRIPTION
When sending exceptions manually you need to be able to set the HttpContext to ensure context information is sent with the Crash Report if available.
When implementing a custom IRaygunAspNetCoreClientProvider you also need access to the HttpContext to determine the logged in user for setting the client RaygunIdentifierMessage.
This change allows both these requirements by exposing overloaded methods that allows the user to pass the current HttpContext.