### PR TITLE
Only read text requests

### DIFF
--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiDelegatingHandler.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiDelegatingHandler.cs
@@ -9,13 +9,27 @@ namespace Mindscape.Raygun4Net.WebApi
 
     protected override async System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
     {
-      var body = await request.Content.ReadAsStringAsync();
-      if (!string.IsNullOrEmpty(body))
+      if (IsText(request))
       {
-        request.Properties[RequestBodyKey] = body.Length > 4096 ? body.Substring(0, 4096) : body;
+        var body = await request.Content.ReadAsStringAsync();
+        if (!string.IsNullOrEmpty(body))
+        {
+          request.Properties[RequestBodyKey] = body.Length > 4096 ? body.Substring(0, 4096) : body;
+        }
       }
 
       return await base.SendAsync(request, cancellationToken);
+    }
+
+    private bool IsText(HttpRequestMessage request)
+    {
+      var mediaType = request.Content.Headers.ContentType?.MediaType?.ToLowerInvariant();
+      if (mediaType == null)
+        return false;
+      if (mediaType == "text/xml" || mediaType == "application/xml" || mediaType == "application/json")
+        return true;
+
+      return mediaType.StartsWith("text/");
     }
   }
 }


### PR DESCRIPTION
This fixes #313 -- which prevents Raygun from reading large binary requests (like file uploads) into memory. 