### PR TITLE
Allowing Raw Data capture for ASP.NET Core

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
@@ -96,9 +96,15 @@ namespace Mindscape.Raygun4Net.Builders
           request.Body.Seek(0, SeekOrigin.Begin);
           string temp = new StreamReader(request.Body).ReadToEnd();
 
+          /*
+           * In ASP.NET Core it seems the request.Form property doesn't get filled in unless it's an actual urlencoded form post.
+           * because of this, the code that gets the ignored values and strips them out is not going to work at all.
+           * To further complicate matters, since we can't rely on request.Form, we'd have to deserialize the request data which could be of virtually any type.
+           */
+
           // If we made it this far, strip out any values that have been marked as ignored form fields
-          Dictionary<string, string> ignored = GetIgnoredFormValues(request.Form, options.IsFormFieldIgnored);
-          temp = StripIgnoredFormData(temp, ignored);
+          //Dictionary<string, string> ignored = GetIgnoredFormValues(request.Form, options.IsFormFieldIgnored);
+          //temp = StripIgnoredFormData(temp, ignored);
 
           if (length > temp.Length)
           {

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunSettings.cs
@@ -33,6 +33,8 @@ namespace Mindscape.Raygun4Net
 
     public bool IsRawDataIgnored { get; set; }
 
+    public bool TransformRequestStream { get; set; }
+
     public string ApplicationVersion { get; set; }
   }
 }

--- a/Mindscape.Raygun4Net.AspNetCore/project.json
+++ b/Mindscape.Raygun4Net.AspNetCore/project.json
@@ -30,9 +30,10 @@
     "frameworks": {
         "netstandard1.6": {
             "imports": "dnxcore50",
-            "dependencies": {
-                "System.Diagnostics.StackTrace": "4.0.1"
-            }
+          "dependencies": {
+            "System.Diagnostics.StackTrace": "4.0.1",
+            "System.Net.WebSockets": "4.0.0"
+          }
         },
         "net451": {
             "frameworkAssemblies": {

--- a/Mindscape.Raygun4Net.AspNetCore/project.lock.json
+++ b/Mindscape.Raygun4Net.AspNetCore/project.lock.json
@@ -6463,7 +6463,8 @@
       "System.Windows.Forms >= 4.0.0"
     ],
     ".NETStandard,Version=v1.6": [
-      "System.Diagnostics.StackTrace >= 4.0.1"
+      "System.Diagnostics.StackTrace >= 4.0.1",
+      "System.Net.WebSockets >= 4.0.0"
     ]
   },
   "tools": {},


### PR DESCRIPTION
I don't think this is necessarily ready for merge but I wanted to get it shared.....

If my understanding is correct in how ASP.NET Core handles requests, then the raw data handling currently in raygun is broken WRT ASP.NET Core in the following ways:

1. Non-Form streams are not rewindable, so this line:
request.Body.Seek(0, SeekOrigin.Begin);
breaks as Seek is not supported, and the stream has already been read. To fix, I implemented an update to the middleware that replaces the incoming stream with one that has CanSeek == true. This is controlled by a new property "TransformRequestStream"

2. After we have a rewindable stream, the code that strips out ignored properties uses request.Form, which is not populated for non urlencoded form posts. It looks like the code to do this is dead code in ASP.NET core, as it is only called when the content type is not a form, so request.Form will always be empty (i think).

For my fix, I removed the function calls that strip the ignore properties. This means that the feature would be completely disabled for ASP.NET Core, though I don't believe it was working at all to begin with based on the above.


Next steps would be to re-implement the ignored fields stripping, but need to take into account the content type, as request.Form is no longer reliable across content types. This would likely include deserializing based on type and working from there. 