### PR TITLE
Fix ignore JavaProxyThrowable handling in recent Xamarin releases

### DIFF
--- a/Mindscape.Raygun4Net.Xamarin.Android.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Android.Tests/RaygunClientTests.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mindscape.Raygun4Net.Messages;
 using NUnit.Framework;
+using Java.Lang;
+using Java.Lang.Reflect;
+using Exception = System.Exception;
 
 namespace Mindscape.Raygun4Net.Xamarin.Android.Tests
 {
@@ -130,6 +131,20 @@ namespace Mindscape.Raygun4Net.Xamarin.Android.Tests
 
       Assert.IsTrue(_client.ExposeOnSendingMessage(message));
       Assert.AreEqual("Custom error message", message.Details.Error.Message);
+    }
+
+    [Test]
+    public void DontSendIfJavaProxyThrowable() {
+      Throwable throwable = Throwable.FromException(_exception);
+
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(throwable)));
+    }
+
+    [Test]
+    public void DontSendIfWrappedJavaProxyThrowable() {
+      Throwable throwable = new RuntimeException(new InvocationTargetException(Throwable.FromException(_exception)));
+
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(throwable)));
     }
 
     // Exception stripping tests


### PR DESCRIPTION
In recent versions of Xamarin (not sure on exact release, but I assume Xamarin.Android 6.1 as the JNI architecture was changed then) the first line in the stack trace had changed to include the top level throwable class name rather than "exception".

Added handling for proxy stack traces in Xamarin.Android 6.1(?)+ and associated tests.

Also fixed handling for non-wrapped throwables which will have `JavaProxyThrowable` on line 2 of the stack trace, and no `Caused by: ` prefix.

#### Example stack traces ####
##### Wrapped #####
```
    --- End of managed Java.Lang.RuntimeException stack trace ---
 java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
 com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120):0
 Caused by: java.lang.reflect.InvocationTargetException
 java.lang.reflect.Method.invoke(Native Method):0
 com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230):0
    ... 1 more
 Caused by: android.runtime.JavaProxyThrowable: System.NullReferenceException: Object reference not set to an instance of an object
```
##### Non-wrapped #####
```
    --- End of managed Android.Runtime.JavaProxyThrowable stack trace ---  
 android.runtime.JavaProxyThrowable: System.NullReferenceException: Object reference not set to an instance of an object
```