### PR TITLE
Xamarin iOS stack trace fix

### DIFF
--- a/AssemblyVersionInfo.cs
+++ b/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.4.1.0")]
-[assembly: AssemblyFileVersion("5.4.1.0")]
+[assembly: AssemblyVersion("5.4.1.1")]
+[assembly: AssemblyFileVersion("5.4.1.1")]

--- a/Mindscape.Raygun4Net.Xamarin.iOS.Tests/Properties/AssemblyInfo.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS.Tests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Raygun")]
 [assembly: AssemblyProduct("Raygun4Net")]
-[assembly: AssemblyCopyright("Copyright © Raygun 2014-2016")]
+[assembly: AssemblyCopyright("Copyright © Raygun 2014-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Mindscape.Raygun4Net.Xamarin.iOS.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS.Tests/RaygunClientTests.cs
@@ -278,11 +278,11 @@ namespace Mindscape.Raygun4Net.Xamarin.iOS.Tests
     {
       string stackTraceStr = @" at XamarinIOSSingleViewTest.AppDelegate+<Bar>d__8.MoveNext () [0x000ad] in C:\Dev\Tests\XamarinIOSTestApplication\XamarinIOSSingleViewTest\AppDelegate.cs:68 
 --- End of stack trace from previous location where exception was thrown ---
-  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Library/Frameworks/Xamarin.iOS.framework/Versions/10.4.0.123/src/mono/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:143 
-  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x00047] in /Library/Frameworks/Xamarin.iOS.framework/Versions/10.4.0.123/src/mono/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:187 
-  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in /Library/Frameworks/Xamarin.iOS.framework/Versions/10.4.0.123/src/mono/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:156 
-  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in /Library/Frameworks/Xamarin.iOS.framework/Versions/10.4.0.123/src/mono/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:128 
-  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/Versions/10.4.0.123/src/mono/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:113 
+  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Library/Frameworks/Xamarin.iOS.framework/system/runtime/exceptionservices/exceptionservicescommon.cs:143 
+  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x00047] in /Library/Frameworks/Xamarin.iOS.framework/system/runtime/compilerservices/TaskAwaiter.cs:187 
+  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in /Library/Frameworks/Xamarin.iOS.framework/system/runtime/compilerservices/TaskAwaiter.cs:156 
+  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in /Library/Frameworks/Xamarin.iOS.framework/system/runtime/compilerservices/TaskAwaiter.cs:128 
+  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/system/runtime/compilerservices/TaskAwaiter.cs:113 
   at XamarinIOSSingleViewTest.AppDelegate+<Foo>d__7.MoveNext () [0x000cf] in C:\Dev\Tests\XamarinIOSTestApplication\XamarinIOSSingleViewTest\AppDelegate.cs:58";
       
       MyTestException exception = new MyTestException("Exception test message", stackTraceStr);
@@ -305,17 +305,17 @@ namespace Mindscape.Raygun4Net.Xamarin.iOS.Tests
     [Test]
     public void FormatStacktraceWithoutDebugSymbolsTest()
     {
-      string stackTraceStr = @"  at MyStudyLife.Net.HttpApiClient+<EnsureSuccessAsync>c__async7.MoveNext () <0xc2b59c + 0x00670> in <06b44c3216694065a06dc13af99a121f#a73e7e6904809cacfd9634d844fe30fc>
+      string stackTraceStr = @"  at RaygunXamarinTest.Net.HttpApiClient+<EnsureSuccessAsync>c__async7.MoveNext () <0xc2b59c + 0x00670> in <06b44c3216694065a06dc13af99a121f#a65e7e6904709cacfd8634d732fe31fb>
 --- End of stack trace from previous location where exception was thrown ---
-  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) <0x47ec74 + 0x00118> in <15e850188d9f425bbeae90f0bbc51e17#a73e7e6904809cacfd9634d844fe30fc>
-  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) <0x47ebac + 0x000bf> in <15e850188d9f425bbeae90f0bbc51e17#a73e7e6904809cacfd9634d844fe30fc>
-  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () <0x47eb68 + 0x0001f> in <15e850188d9f425bbeae90f0bbc51e17#a73e7e6904809cacfd9634d844fe30fc>
-  at MyStudyLife.Net.HttpApiClient+<GetClientResponse>c__async6.MoveNext () <0xb89040 + 0x00407> in <06b44c3216694065a06dc13af99a121f#a73e7e6904809cacfd9634d844fe30fc>
+  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) <0x47ec74 + 0x00118> in <15e850188d9f425bbeae90f0bbc51e17#a65e7e6904709cacfd8634d732fe31fb>
+  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) <0x47ebac + 0x000bf> in <15e850188d9f425bbeae90f0bbc51e17#a65e7e6904709cacfd8634d732fe31fb>
+  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () <0x47eb68 + 0x0001f> in <15e850188d9f425bbeae90f0bbc51e17#a65e7e6904709cacfd8634d732fe31fb>
+  at RaygunXamarinTest.Net.HttpApiClient+<GetClientResponse>c__async6.MoveNext () <0xb89040 + 0x00407> in <06b44c3216694065a06dc13af99a121f#a65e7e6904709cacfd8634d732fe31fb>
 --- End of stack trace from previous location where exception was thrown ---
-  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) <0x47ec74 + 0x00118> in <15e850188d9f425bbeae90f0bbc51e17#a73e7e6904809cacfd9634d844fe30fc>
-  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) <0x47ebac + 0x000bf> in <15e850188d9f425bbeae90f0bbc51e17#a73e7e6904809cacfd9634d844fe30fc>
-  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () <0x47ee98 + 0x0002f> in <15e850188d9f425bbeae90f0bbc51e17#a73e7e6904809cacfd9634d844fe30fc>
-  at MyStudyLife.Net.HttpApiClient+<PostJsonAsync>c__async2.MoveNext () <0xb88598 + 0x0019b> in <06b44c3216694065a06dc13af99a121f#a73e7e6904809cacfd9634d844fe30fc>";
+  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) <0x47ec74 + 0x00118> in <15e850188d9f425bbeae90f0bbc51e17#a65e7e6904709cacfd8634d732fe31fb>
+  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) <0x47ebac + 0x000bf> in <15e850188d9f425bbeae90f0bbc51e17#a65e7e6904709cacfd8634d732fe31fb>
+  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () <0x47ee98 + 0x0002f> in <15e850188d9f425bbeae90f0bbc51e17#a65e7e6904709cacfd8634d732fe31fb>
+  at RaygunXamarinTest.Net.HttpApiClient+<PostJsonAsync>c__async2.MoveNext () <0xb88598 + 0x0019b> in <06b44c3216694065a06dc13af99a121f#a65e7e6904709cacfd8634d732fe31fb>";
 
       MyTestException exception = new MyTestException("Exception test message", stackTraceStr);
       var message = RaygunErrorMessageBuilder.Build(exception);

--- a/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Properties/AssemblyInfo.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Raygun")]
 [assembly: AssemblyProduct("Raygun4Net")]
-[assembly: AssemblyCopyright("Copyright © Raygun 2014-2016")]
+[assembly: AssemblyCopyright("Copyright © Raygun 2014-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]

--- a/Mindscape.Raygun4Net.Xamarin.iOS/Properties/AssemblyInfo.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Raygun")]
 [assembly: AssemblyProduct("Raygun4Net")]
-[assembly: AssemblyCopyright("Copyright © Raygun 2013-2016")]
+[assembly: AssemblyCopyright("Copyright © Raygun 2013-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Made the stack trace parsing more flexible to take into account stack traces without debug symbols and line numbers. This also fixes the hashing of xamarin ios errors that rely on the class name and method name being valid. These properties were not filled out if the line number was not present.