### PR TITLE
RaygunMessage Initializer Support

### DIFF
--- a/Mindscape.Raygun4Net.Core/IRaygunMessageInitializer.cs
+++ b/Mindscape.Raygun4Net.Core/IRaygunMessageInitializer.cs
@@ -1,0 +1,20 @@
+﻿using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net
+{
+  /// <summary>
+  /// Represents an initializer for <see cref="RaygunMessage"/> objects.
+  /// </summary>
+  /// <remarks>
+  /// The Raygun Clients use registered <see cref="IRaygunMessageInitializer"/>
+  /// to automatically add additional properties to <see cref="RaygunMessage"/> objects.
+  /// </remarks>
+  public interface IRaygunMessageInitializer
+  {
+    /// <summary>
+    /// Initializes properties of the specified <see cref="RaygunMessage"/> object.
+    /// </summary>
+    /// <param name="raygunMessage">The <see cref="RaygunMessage"/> to initialize.</param>
+    void Initialize(RaygunMessage raygunMessage);
+  }
+}

--- a/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
+++ b/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
@@ -121,6 +121,7 @@
       <Link>SimpleJson.cs</Link>
     </Compile>
     <Compile Include="Builders\RaygunErrorMessageBuilder.cs" />
+    <Compile Include="IRaygunMessageInitializer.cs" />
     <Compile Include="Messages\RaygunErrorMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Mindscape.Raygun4Net.WebApi.Tests/Mindscape.Raygun4Net.WebApi.Tests.csproj
+++ b/Mindscape.Raygun4Net.WebApi.Tests/Mindscape.Raygun4Net.WebApi.Tests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Model\FakeRaygunWebApiClient.cs" />
+    <Compile Include="Model\TestRaygunMessageInitializer.cs" />
     <Compile Include="Model\WrapperException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RaygunWebApiClientTests.cs" />

--- a/Mindscape.Raygun4Net.WebApi.Tests/Model/FakeRaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/Model/FakeRaygunWebApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Mindscape.Raygun4Net.Messages;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Mindscape.Raygun4Net.WebApi.Tests.Model
@@ -14,6 +15,11 @@ namespace Mindscape.Raygun4Net.WebApi.Tests.Model
     public IEnumerable<Exception> ExposeStripWrapperExceptions(Exception exception)
     {
       return base.StripWrapperExceptions(exception);
+    }
+
+    public RaygunMessage ExposeBuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData, DateTime? currentTime = null)
+    {
+      return base.BuildMessage(exception, tags, userCustomData, currentTime);
     }
   }
 }

--- a/Mindscape.Raygun4Net.WebApi.Tests/Model/TestRaygunMessageInitializer.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/Model/TestRaygunMessageInitializer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net.WebApi.Tests.Model
+{
+  public class TestRaygunMessageInitializer : IRaygunMessageInitializer
+  {
+    public void Initialize(RaygunMessage raygunMessage)
+    {
+      if (raygunMessage.Details.UserCustomData == null)
+      {
+        raygunMessage.Details.UserCustomData = new Dictionary<string, object>();
+      }
+      raygunMessage.Details.UserCustomData["initializerTestData"] = "true";
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.WebApi.Tests/RaygunWebApiClientTests.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/RaygunWebApiClientTests.cs
@@ -265,5 +265,14 @@ namespace Mindscape.Raygun4Net.WebApi.Tests
       Assert.IsTrue(ex1.Data["Type"].ToString().Contains("FakeRaygunWebApiClient"));
       Assert.IsTrue(ex2.Data["Type"].ToString().Contains("WrapperException"));
     }
+
+    [Test]
+    public void CanUseInitializerToSetData()
+    {
+      _client.AddMessageInitializer(new TestRaygunMessageInitializer());
+      var message = _client.ExposeBuildMessage(_exception, null, null);
+
+      Assert.IsTrue(message.Details.UserCustomData.Contains("initializerTestData"));
+    }
   }
 }

--- a/Mindscape.Raygun4Net/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net/RaygunClientBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using Mindscape.Raygun4Net.Messages;
 
@@ -113,6 +114,44 @@ namespace Mindscape.Raygun4Net
         }
       }
       return result;
+    }
+
+    /// <summary>
+    /// List of registered <see cref="IRaygunMessageInitializer"/> objects.
+    /// </summary>
+    private List<IRaygunMessageInitializer> RaygunMessageInitializers { get; set; } = new List<IRaygunMessageInitializer>();
+
+    /// <summary>
+    /// Return a copy of the registered <see cref="IRaygunMessageInitializer"/> objects.
+    /// </summary>
+    /// <remarks>
+    /// Ensures that changes made to the collection during processing does not cause problems.
+    /// </remarks>
+    protected virtual List<IRaygunMessageInitializer> GetRaygunMessageInitializers()
+    {
+      return new List<IRaygunMessageInitializer>(RaygunMessageInitializers);
+    }
+
+    /// <summary>
+    /// Register a <see cref="IRaygunMessageInitializer"/> to initialize properties on the <see cref="RaygunMessage"/>.
+    /// </summary>
+    /// <param name="raygunMessageInitializer">The <see cref="IRaygunMessageInitializer"/> to register.</param>
+    public virtual void AddMessageInitializer(IRaygunMessageInitializer raygunMessageInitializer)
+    {
+      if (RaygunMessageInitializers == null)
+      {
+        RaygunMessageInitializers = new List<IRaygunMessageInitializer>();
+      }
+      RaygunMessageInitializers.Add(raygunMessageInitializer);
+    }
+
+    /// <summary>
+    /// Removes a <see cref="IRaygunMessageInitializer"/> from the list of registered <see cref="IRaygunMessageInitializer"/> objects.
+    /// </summary>
+    /// <param name="raygunMessageInitializer">The <see cref="IRaygunMessageInitializer"/> to remove.</param>
+    public virtual bool RemoveMessageInitializer(IRaygunMessageInitializer raygunMessageInitializer)
+    {
+      return RaygunMessageInitializers.Remove(raygunMessageInitializer);
     }
 
     /// <summary>


### PR DESCRIPTION
Hey!

We use raygun a lot and love it, but ran into a lot of restrictions when trying to enrich our exception reports with information residing on the current thread.

Other libraries we use commonly have the concept of Initializers - customer-added code that runs directly after the message is created.

I have recreated that functionality by building out support for it in the base Raygun4Net project, and then implemented it in the Raygun4Net.WebApi project. 

In order to ensure the initializers run on correct thread, I had to move the Threadpool to send the message to Raygun down the stack, after the message has been built. This also allows for removing the ThreadLocal RaygunRequestMessage, as we can now build it directly in the BuildMessage call.

I matched your code standards to the best of my abilities and documented all public calls. I also added a unit test that shows how to use it, and verifies the behavior.

Please let me know if you have any questions, or need me to change something!

This would also solve #347 & #297 