### PR TITLE
Added support for request body in projects with owin

### DIFF
--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -132,13 +132,9 @@ namespace Mindscape.Raygun4Net.WebApi
       {
         applicationVersion = applicationVersionFromAttach;
       }
-
-      var owinAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName.StartsWith("Owin"));
-      if (owinAssembly == null)
-      {
-        config.MessageHandlers.Add(new RaygunWebApiDelegatingHandler());
-      }
-
+      
+      config.MessageHandlers.Add(new RaygunWebApiDelegatingHandler());
+      
       var clientCreator = new RaygunWebApiClientProvider(generateRaygunClientWithMessage, applicationVersion);
 
       config.Services.Add(typeof(IExceptionLogger), new RaygunWebApiExceptionLogger(clientCreator));

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiDelegatingHandler.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiDelegatingHandler.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -11,21 +13,11 @@ namespace Mindscape.Raygun4Net.WebApi
 
     protected override async System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
     {
-      var stream = await request.Content.ReadAsStreamAsync();
-      if (stream != null && stream.CanSeek)
+      // ReadAsStringAsync is always readable as it calls LoadIntoBufferAsync internally.
+      var body = await request.Content.ReadAsStringAsync();
+      if (!string.IsNullOrEmpty(body))
       {
-        var lengthToRead = (int)(stream.Length < 4096 ? stream.Length : 4096);
-        var buffer = new byte[lengthToRead];
-
-        await stream.ReadAsync(buffer, 0, lengthToRead, cancellationToken);
-
-        var body = Encoding.UTF8.GetString(buffer);
-        if (!string.IsNullOrEmpty(body))
-        {
-          request.Properties[RequestBodyKey] = body;
-        }
-
-        stream.Seek(0, System.IO.SeekOrigin.Begin);
+        request.Properties[RequestBodyKey] = body;
       }
 
       return await base.SendAsync(request, cancellationToken);


### PR DESCRIPTION
This is a PR for issue https://github.com/MindscapeHQ/raygun4net/issues/288.

This seems far too simple to be correct, but in all my testing it appears to work very well.  I have replicated the original issue with Owin and the issue no longer occurs with this new code.

The new code works because **ReadAsStringAsync** is always readable because it calls **LoadIntoBufferAsync** internally which then uses an internal buffer to allow re-reads.

This is the solution provided here: https://stackoverflow.com/a/13021877/584285