### PR TITLE
Easily disable the HttpModule in code

### DIFF
--- a/Mindscape.Raygun4Net/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net/RaygunHttpModule.cs
@@ -7,6 +7,8 @@ namespace Mindscape.Raygun4Net
 {
   public class RaygunHttpModule : IHttpModule
   {
+    public static bool Enabled = true;
+
     private bool ExcludeErrorsBasedOnHttpStatusCode { get; set; }
     private bool ExcludeErrorsFromLocal { get; set; }
 
@@ -14,6 +16,8 @@ namespace Mindscape.Raygun4Net
 
     public void Init(HttpApplication context)
     {
+      if (!Enabled) return;
+
       context.Error += SendError;
       HttpStatusCodesToExclude = RaygunSettings.Settings.ExcludedStatusCodes;
       ExcludeErrorsBasedOnHttpStatusCode = HttpStatusCodesToExclude.Any();

--- a/Mindscape.Raygun4Net/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net/RaygunHttpModule.cs
@@ -7,7 +7,7 @@ namespace Mindscape.Raygun4Net
 {
   public class RaygunHttpModule : IHttpModule
   {
-    public static bool Enabled = true;
+    public static bool Disabled { get; set; }
 
     private bool ExcludeErrorsBasedOnHttpStatusCode { get; set; }
     private bool ExcludeErrorsFromLocal { get; set; }
@@ -16,7 +16,7 @@ namespace Mindscape.Raygun4Net
 
     public void Init(HttpApplication context)
     {
-      if (!Enabled) return;
+      if (Disabled) return;
 
       context.Error += SendError;
       HttpStatusCodesToExclude = RaygunSettings.Settings.ExcludedStatusCodes;


### PR DESCRIPTION
We like to report errors ourselves, so we need a way to disable the module. I'm open to better suggestions.