### PR TITLE
Fix StackOverflowException with .NET Core client

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
-    <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mindscape.Raygun4Net.NetCore.Common\Mindscape.Raygun4Net.NetCore.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -7,7 +7,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting ASP.Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.AspNetCore</PackageId>
-    <PackageVersion>6.0.0</PackageVersion>
+    <PackageVersion>6.0.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.0")]
-[assembly: AssemblyFileVersion("6.0.0")]
+[assembly: AssemblyVersion("6.0.1")]
+[assembly: AssemblyFileVersion("6.0.1")]

--- a/Mindscape.Raygun4Net.AspNetCore/readme.txt
+++ b/Mindscape.Raygun4Net.AspNetCore/readme.txt
@@ -13,7 +13,7 @@ The main classes can be found in the Mindscape.Raygun4Net namespace.
 Usage
 ======
 
-In your project.json file, add "Mindscape.Raygun4Net.AspNetCore": "6.0.0" to your dependencies.
+In your project.json file, add "Mindscape.Raygun4Net.AspNetCore": "6.0.1" to your dependencies.
 
 Run dotnet.exe restore or restore packages within Visual Studio to download the package.
 

--- a/Mindscape.Raygun4Net.AspNetCore2.Tests.TestLib/Mindscape.Raygun4Net.AspNetCore2.Tests.TestLib.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore2.Tests.TestLib/Mindscape.Raygun4Net.AspNetCore2.Tests.TestLib.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="6.0.0" />
+    <ProjectReference Include="..\Mindscape.Raygun4Net.NetCore\Mindscape.Raygun4Net.NetCore.csproj" />
   </ItemGroup>
 </Project>

--- a/Mindscape.Raygun4Net.AspNetCore2.Tests/Mindscape.Raygun4Net.AspNetCore2.Tests.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore2.Tests/Mindscape.Raygun4Net.AspNetCore2.Tests.csproj
@@ -4,12 +4,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mindscape.Raygun4Net.AspNetCore2.Tests.TestLib\Mindscape.Raygun4Net.AspNetCore2.Tests.TestLib.csproj" />
+    <ProjectReference Include="..\Mindscape.Raygun4Net.AspNetCore\Mindscape.Raygun4Net.AspNetCore.csproj" />
   </ItemGroup>
 </Project>

--- a/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunClientMessage.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunClientMessage.cs
@@ -5,7 +5,7 @@
     public RaygunClientMessage()
     {
       Name = "Raygun4Net.NetCore";
-      Version = "6.0.0";
+      Version = "6.0.1";
       ClientUrl = @"https://github.com/MindscapeHQ/raygun4net";
     }
     

--- a/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
+++ b/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
@@ -16,4 +16,13 @@
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">
+    <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD1_6</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
+++ b/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
@@ -6,7 +6,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library .NetCore applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore.Common</PackageId>
-    <PackageVersion>6.0.0</PackageVersion>
+    <PackageVersion>6.0.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore.Common/SimpleJson.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/SimpleJson.cs
@@ -42,15 +42,15 @@
 // usually already defined in properties
 //#define NETFX_CORE;
 
-// If you are targetting WinStore, WP8, NET4.5+ PCL, or .NET Core make sure to #define SIMPLE_JSON_TYPEINFO;
+// If you are targetting WinStore, WP8 and NET4.5+ PCL make sure to #define SIMPLE_JSON_TYPEINFO;
 
-#define SIMPLE_JSON_TYPEINFO
+// #define SIMPLE_JSON_TYPEINFO
 
 // original json parsing code from http://techblog.procurios.nl/k/618/news/view/14605/14863/How-do-I-write-my-own-parser-for-JSON.html
 
-#if NETFX_CORE
+//#if NETSTANDARD1_6
 #define SIMPLE_JSON_TYPEINFO
-#endif
+//#endif
 
 using System;
 using System.CodeDom.Compiler;
@@ -66,6 +66,7 @@ using System.Dynamic;
 #endif
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Text;
 using Mindscape.Raygun4Net.Reflection;
 
@@ -74,10 +75,10 @@ using Mindscape.Raygun4Net.Reflection;
 // ReSharper disable SuggestUseVarKeywordEvident
 namespace Mindscape.Raygun4Net
 {
-  /// <summary>
-  /// Represents the json array.
-  /// </summary>
-  [GeneratedCode("simple-json", "1.0.0")]
+    /// <summary>
+    /// Represents the json array.
+    /// </summary>
+    [GeneratedCode("simple-json", "1.0.0")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
 #if SIMPLE_JSON_OBJARRAYINTERNAL
@@ -483,13 +484,6 @@ namespace Mindscape.Raygun4Net
         }
 #endif
     }
-
-  public class JsonSerializationException : Exception
-  {
-    public JsonSerializationException(string message) : base(message)
-    {
-    }
-  }
 }
 
 namespace Mindscape.Raygun4Net
@@ -551,7 +545,7 @@ namespace Mindscape.Raygun4Net
       object obj;
       if (TryDeserializeObject(json, out obj))
         return obj;
-      throw new JsonSerializationException("Invalid JSON string");
+      throw new SerializationException("Invalid JSON string");
     }
 
     /// <summary>
@@ -1028,7 +1022,6 @@ namespace Mindscape.Raygun4Net
 
       if (visited.Contains(value))
       {
-        visited.Pop();
         return SerializeString(CYCLIC_MESSAGE, builder); ;
       }
 
@@ -1040,41 +1033,49 @@ namespace Mindscape.Raygun4Net
         success = SerializeString(stringValue, builder);
       else
       {
-        IDictionary dict = value as IDictionary;
-        if (dict != null)
+        if (value.GetType().IsArray)
         {
-          success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder, visited);
+          success = SerializeArray(jsonSerializerStrategy, value as IEnumerable, builder, visited);
         }
         else
         {
-          IDictionary<string, object> stringObjectDictionary = value as IDictionary<string, object>;
-          if (stringObjectDictionary != null)
+          IDictionary dict = value as IDictionary;
+          if (dict != null)
           {
-            success = SerializeObject(jsonSerializerStrategy, stringObjectDictionary.Keys, stringObjectDictionary.Values, builder, visited);
+            success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder, visited);
           }
           else
           {
-            IDictionary<string, string> stringDictionary = value as IDictionary<string, string>;
-            if (stringDictionary != null)
+            IDictionary<string, object> stringObjectDictionary = value as IDictionary<string, object>;
+            if (stringObjectDictionary != null)
             {
-              success = SerializeObject(jsonSerializerStrategy, stringDictionary.Keys, stringDictionary.Values, builder, visited);
+              success = SerializeObject(jsonSerializerStrategy, stringObjectDictionary.Keys, stringObjectDictionary.Values, builder, visited);
             }
             else
             {
-              IEnumerable enumerableValue = value as IEnumerable;
-              if (enumerableValue != null)
-                success = SerializeArray(jsonSerializerStrategy, enumerableValue, builder, visited);
-              else if (IsNumeric (value))
-                success = SerializeNumber(value, builder);
-              else if (value is bool)
-                builder.Append ((bool)value ? "true" : "false");
-              else if (value == null)
-                builder.Append("null");
-              else {
-                object serializedObject;
-                success = jsonSerializerStrategy.TrySerializeNonPrimitiveObject(value, out serializedObject);
-                if (success)
-                  SerializeValue(jsonSerializerStrategy, serializedObject, builder, visited);
+              IDictionary<string, string> stringDictionary = value as IDictionary<string, string>;
+              if (stringDictionary != null)
+              {
+                success = SerializeObject(jsonSerializerStrategy, stringDictionary.Keys, stringDictionary.Values, builder, visited);
+              }
+              else
+              {
+                IEnumerable enumerableValue = value as IEnumerable;
+                if (enumerableValue != null)
+                  success = SerializeArray(jsonSerializerStrategy, enumerableValue, builder, visited);
+                else if (IsNumeric(value))
+                  success = SerializeNumber(value, builder);
+                else if (value is bool)
+                  builder.Append((bool)value ? "true" : "false");
+                else if (value == null)
+                  builder.Append("null");
+                else
+                {
+                  object serializedObject;
+                  success = jsonSerializerStrategy.TrySerializeNonPrimitiveObject(value, out serializedObject);
+                  if (success)
+                    SerializeValue(jsonSerializerStrategy, serializedObject, builder, visited);
+                }
               }
             }
           }
@@ -1558,6 +1559,8 @@ namespace Mindscape.Raygun4Net
         output = ((Guid)input).ToString("D");
       else if (input is Uri)
         output = input.ToString();
+      else if (input is Type)
+        output = ((Type)input).AssemblyQualifiedName;
       else
       {
         Enum inputEnum = input as Enum;

--- a/Mindscape.Raygun4Net.NetCore.Common/SimpleJson.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/SimpleJson.cs
@@ -48,9 +48,9 @@
 
 // original json parsing code from http://techblog.procurios.nl/k/618/news/view/14605/14863/How-do-I-write-my-own-parser-for-JSON.html
 
-//#if NETSTANDARD1_6
+#if NETSTANDARD1_6
 #define SIMPLE_JSON_TYPEINFO
-//#endif
+#endif
 
 using System;
 using System.CodeDom.Compiler;

--- a/Mindscape.Raygun4Net.NetCore.Tests/Mindscape.Raygun4Net.NetCore.Tests.csproj
+++ b/Mindscape.Raygun4Net.NetCore.Tests/Mindscape.Raygun4Net.NetCore.Tests.csproj
@@ -5,14 +5,15 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Mindscape.Raygun4Net.NetCore\Mindscape.Raygun4Net.NetCore.csproj" />
+    <Compile Remove="Model\FakeRaygunRequestMessageBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="Model\FakeRaygunRequestMessageBuilder.cs" />
+    <ProjectReference Include="..\Mindscape.Raygun4Net.NetCore.Common\Mindscape.Raygun4Net.NetCore.Common.csproj" />
+    <ProjectReference Include="..\Mindscape.Raygun4Net.NetCore\Mindscape.Raygun4Net.NetCore.csproj" />
   </ItemGroup>
 </Project>

--- a/Mindscape.Raygun4Net.NetCore.Tests/SimpleJsonTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/SimpleJsonTests.cs
@@ -92,7 +92,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     public void SerializeTypeObject()
     {
       string json = SimpleJson.SerializeObject(typeof(FakeRaygunClient));
-      Assert.AreEqual("\"Mindscape.Raygun4Net.Tests.FakeRaygunClient, Mindscape.Raygun4Net.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\"", json);
+      Assert.AreEqual("\"Mindscape.Raygun4Net.NetCore.Tests.FakeRaygunClient, Mindscape.Raygun4Net.NetCore.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\"", json);
     }
 
     [Test]
@@ -100,7 +100,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     {
       var o = new { Type = typeof(FakeRaygunClient) };
       string json = SimpleJson.SerializeObject(o);
-      Assert.AreEqual("{\"Type\":\"Mindscape.Raygun4Net.Tests.FakeRaygunClient, Mindscape.Raygun4Net.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\"}", json);
+      Assert.AreEqual("{\"Type\":\"Mindscape.Raygun4Net.NetCore.Tests.FakeRaygunClient, Mindscape.Raygun4Net.NetCore.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\"}", json);
     }
 
     // Cyclic object structure tests

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -40,6 +40,6 @@
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="6.0.0" />
+    <ProjectReference Include="..\Mindscape.Raygun4Net.NetCore.Common\Mindscape.Raygun4Net.NetCore.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -27,15 +27,11 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-  </ItemGroup>
   <!-- .NET Standard 1.6 references, compilation flags and build options -->
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">
     <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD1_6</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
   </ItemGroup>

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -12,7 +12,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting .Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore</PackageId>
-    <PackageVersion>6.0.0</PackageVersion>
+    <PackageVersion>6.0.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.NetCore/Properties/AssemblyVersionInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.0")]
-[assembly: AssemblyFileVersion("6.0.0")]
+[assembly: AssemblyVersion("6.0.1")]
+[assembly: AssemblyFileVersion("6.0.1")]

--- a/Mindscape.Raygun4Net.NetCore/readme.txt
+++ b/Mindscape.Raygun4Net.NetCore/readme.txt
@@ -13,7 +13,7 @@ The main classes can be found in the Mindscape.Raygun4Net namespace.
 Usage
 =====
 
-In your project file, add "Mindscape.Raygun4Net.NetCore": "6.0.0" to your dependencies.
+In your project file, add "Mindscape.Raygun4Net.NetCore": "6.0.1" to your dependencies.
 
 Run dotnet.exe restore or restore packages within Visual Studio to download the package.
 

--- a/buildAspNetCore.ps1
+++ b/buildAspNetCore.ps1
@@ -1,2 +1,0 @@
-dotnet pack .\Mindscape.Raygun4Net.AspNetCore\ --output build\AspNetCore --configuration Release
-dotnet pack .\Mindscape.Raygun4Net.NetCore.Common\ --output build\NetCoreCommon --configuration Release

--- a/buildNetCore.ps1
+++ b/buildNetCore.ps1
@@ -3,6 +3,7 @@ properties {
     $configuration =                 "Release"
     $build_dir =                     "$root\build\"
     $build_dir_net_core =            "$build_dir\NetCore"
+	$build_dir_aspnet_core  =        "$build_dir\ASPNetCore"
 	$build_dir_net_core_common  =    "$build_dir\NetCoreCommon"
     $nunit_dir =                     "$root\packages\NUnit.Runners.2.6.2\tools\"
     $tools_dir =                     "$root\tools"
@@ -14,11 +15,13 @@ task default -depends Compile
 
 task Clean {
     remove-item -force -recurse $build_dir_net_core -ErrorAction SilentlyContinue | Out-Null
+    remove-item -force -recurse $build_dir_aspnet_core -ErrorAction SilentlyContinue | Out-Null
 	remove-item -force -recurse $build_dir_net_core_common -ErrorAction SilentlyContinue | Out-Null
 }
 
 task Init -depends Clean {
     new-item $build_dir_net_core -itemType directory | Out-Null
+    new-item $build_dir_aspnet_core -itemType directory | Out-Null
 	new-item $build_dir_net_core_common -itemType directory | Out-Null
 }
 
@@ -28,4 +31,7 @@ task Compile -depends Init {
 	
 	exec { dotnet pack .\Mindscape.Raygun4Net.NetCore\ --output build\NetCore --configuration Release }
     move-item -Path $root\Mindscape.Raygun4Net.NetCore\build\NetCore\* -Destination $build_dir_net_core
+	
+	exec { dotnet pack .\Mindscape.Raygun4Net.AspNetCore\ --output build\AspNetCore --configuration Release }
+    move-item -Path $root\Mindscape.Raygun4Net.AspNetCore\build\AspNetCore\* -Destination $build_dir_aspnet_core
 }


### PR DESCRIPTION
It appears modifications had been made to the SimpleJson class to work with Net core, however these modifications weren't needed and broke the recursive serialization checks. The PR brings the implementation back in line with the version in the full framework project and resolves #392 

Other minor fixes
- Removed Newtonsoft.Json as a package reference.
- Fixed file references between projects to be project references and not nuget references.
- Fixed SimpleJson unit tests as these must have never been run.