### PR TITLE
Automatic unhandled exception tag

### DIFF
--- a/AssemblyVersionInfo.cs
+++ b/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.7.0.0")]
-[assembly: AssemblyFileVersion("5.7.0.0")]
+[assembly: AssemblyVersion("5.8.0.0")]
+[assembly: AssemblyFileVersion("5.8.0.0")]

--- a/Mindscape.Raygun4Net.Core.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Core.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Core.Signed</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Core.nuspec
+++ b/Mindscape.Raygun4Net.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Core</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Mvc.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc.Signed</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Mvc.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Signed</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.WebApi.Signed.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.WebApi.Signed</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title>Raygun for ASP.NET Web API</title>
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.WebApi.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.WebApi</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title>Raygun for ASP.NET Web API</title>
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.WebApi/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.WebApi/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.7.0.0")]
-[assembly: AssemblyFileVersion("5.7.0.0")]
+[assembly: AssemblyVersion("5.8.0.0")]
+[assembly: AssemblyFileVersion("5.8.0.0")]

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -18,6 +18,8 @@ namespace Mindscape.Raygun4Net.WebApi
 {
   public class RaygunWebApiClient : RaygunClientBase
   {
+    internal const string UnhandledExceptionTag = "UnhandledException";
+
     private readonly string _apiKey;
     protected readonly RaygunRequestMessageOptions _requestMessageOptions = new RaygunRequestMessageOptions();
     private readonly List<Type> _wrapperExceptions = new List<Type>();

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiControllerActivator.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiControllerActivator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Dispatcher;
@@ -25,13 +26,13 @@ namespace Mindscape.Raygun4Net.WebApi
       catch(InvalidOperationException ex)
       {
         var client = _clientCreator.GenerateRaygunWebApiClient(request);
-        client.SendInBackground(ex.InnerException);
+        client.SendInBackground(ex.InnerException, new List<string> {RaygunWebApiClient.UnhandledExceptionTag});
         client.FlagExceptionAsSent(ex); // Stops us re-sending the outer exception
         throw;
       }
       catch(Exception ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex);
+        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
         throw;
       }
     }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiFilters.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiFilters.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http.Filters;
@@ -19,13 +19,13 @@ namespace Mindscape.Raygun4Net.WebApi
 
     public override void OnException(HttpActionExecutedContext context)
     {
-      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
     }
 
 #pragma warning disable 1998
     public override async Task OnExceptionAsync(HttpActionExecutedContext context, CancellationToken cancellationToken)
     {
-      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
     }
 #pragma warning restore 1998
   }
@@ -50,7 +50,7 @@ namespace Mindscape.Raygun4Net.WebApi
           string.Format("HTTP {0} returned while handling Request {2} {1}", (int)context.Response.StatusCode, context.Request.RequestUri, context.Request.Method),
           context.Response);
 
-        _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(e);
+        _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(e, new List<string> {RaygunWebApiClient.UnhandledExceptionTag});
       }
     }
   }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiSelectors.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiSelectors.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Dispatcher;
@@ -24,7 +25,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch (HttpResponseException ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient(controllerContext.Request).SendInBackground(ex);
+        _clientCreator.GenerateRaygunWebApiClient(controllerContext.Request).SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
         throw;
       }
     }
@@ -59,7 +60,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch (HttpResponseException ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex);
+        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
         throw;
       }
     }

--- a/Mindscape.Raygun4Net.nuspec
+++ b/Mindscape.Raygun4Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net</id>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -17,6 +17,8 @@ namespace Mindscape.Raygun4Net
 {
   public class RaygunClient : RaygunClientBase
   {
+    internal const string UnhandledExceptionTag = "UnhandledException";
+
     private readonly string _apiKey;
     private readonly RaygunRequestMessageOptions _requestMessageOptions = new RaygunRequestMessageOptions();
     private readonly List<Type> _wrapperExceptions = new List<Type>();

--- a/Mindscape.Raygun4Net/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net/RaygunHttpModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Web;
@@ -41,7 +42,7 @@ namespace Mindscape.Raygun4Net
       if (CanSend(lastError))
       {
         var client = GetRaygunClient(application);
-        client.SendInBackground(lastError);
+        client.SendInBackground(lastError, new List<string> {RaygunClient.UnhandledExceptionTag});
       }
     }
 
@@ -50,7 +51,7 @@ namespace Mindscape.Raygun4Net
       if (CanSend(exception))
       {
         var client = GetRaygunClient(application);
-        client.SendInBackground(exception);
+        client.SendInBackground(exception, new List<string> { RaygunClient.UnhandledExceptionTag });
       }
     }
 

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -19,6 +19,8 @@ namespace Mindscape.Raygun4Net
 {
   public class RaygunClient : RaygunClientBase
   {
+    internal const string UnhandledExceptionTag = "UnhandledException";
+
     private readonly string _apiKey;
     private readonly RaygunRequestMessageOptions _requestMessageOptions = new RaygunRequestMessageOptions();
     private readonly List<Type> _wrapperExceptions = new List<Type>();


### PR DESCRIPTION
Any part of Raygun4Net that automatically sends exceptions will now add the "UnhandledException" tag just like other providers. This is used to distinguish uncaught exceptions (likely application crashes) vs exceptions sent from try/catch blocks. Currently applies to ASP .NET, MVC and WebAPI projects.