### PR TITLE
Intercomm ticket resolution

### DIFF
--- a/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
+++ b/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
@@ -84,6 +84,7 @@
     <Compile Include="RaygunWebApiExceptionLogger.cs" />
     <Compile Include="RaygunWebApiFilters.cs" />
     <Compile Include="RaygunWebApiMessageBuilder.cs" />
+    <Compile Include="WebClientHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiDelegatingHandler.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiDelegatingHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 
@@ -23,7 +24,16 @@ namespace Mindscape.Raygun4Net.WebApi
         }
       }
 
-      return await base.SendAsync(request, cancellationToken);
+      var response = await base.SendAsync(request, cancellationToken);
+      if (cancellationToken.IsCancellationRequested)
+      {
+        return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+          ReasonPhrase = "The request was cancelled by the client"
+        };
+      }
+
+      return response;
     }
   }
 }

--- a/Mindscape.Raygun4Net.WebApi/WebClientHelper.cs
+++ b/Mindscape.Raygun4Net.WebApi/WebClientHelper.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Net;
 
-namespace Mindscape.Raygun4Net.WebApi
+namespace Mindscape.Raygun4Net
 {
+
     public static class WebClientHelper
     {
+        [ThreadStatic]
         private static WebClient _client;
 
         private static WebClient Client => _client ?? (_client = new WebClient());

--- a/Mindscape.Raygun4Net.WebApi/WebClientHelper.cs
+++ b/Mindscape.Raygun4Net.WebApi/WebClientHelper.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net;
+
+namespace Mindscape.Raygun4Net.WebApi
+{
+    public static class WebClientHelper
+    {
+        private static WebClient _client;
+
+        private static WebClient Client => _client ?? (_client = new WebClient());
+        private static readonly Uri ProxyUri;
+
+
+        static WebClientHelper()
+        {
+            ProxyUri = WebRequest.DefaultWebProxy.GetProxy(new Uri(RaygunSettings.Settings.ApiEndpoint.ToString()));
+        }
+
+        public static void Send(string message, string apiKey, ICredentials proxyCredentials)
+        {
+            Client.Headers.Clear();
+            Client.Headers.Add("X-ApiKey", apiKey);
+            Client.Headers.Add("content-type", "application/json; charset=utf-8");
+            Client.Encoding = System.Text.Encoding.UTF8;
+
+            if (WebRequest.DefaultWebProxy != null)
+            {
+
+                if (ProxyUri != null && ProxyUri.AbsoluteUri != RaygunSettings.Settings.ApiEndpoint.ToString())
+                {
+                    Client.Proxy = new WebProxy(ProxyUri, false);
+
+                    if (proxyCredentials == null)
+                    {
+                        Client.UseDefaultCredentials = true;
+                        Client.Proxy.Credentials = CredentialCache.DefaultCredentials;
+                    }
+                    else
+                    {
+                        Client.UseDefaultCredentials = false;
+                        Client.Proxy.Credentials = proxyCredentials;
+                    }
+                }
+            }
+
+            Client.UploadString(RaygunSettings.Settings.ApiEndpoint, message);
+        }
+    }
+}

--- a/Mindscape.Raygun4Net/SimpleJson.cs
+++ b/Mindscape.Raygun4Net/SimpleJson.cs
@@ -1022,7 +1022,7 @@ namespace Mindscape.Raygun4Net
 
       if (visited.Contains(value))
       {
-        return SerializeString(CYCLIC_MESSAGE, builder); ;
+        return SerializeString(CYCLIC_MESSAGE, builder); 
       }
 
       visited.Push(value);

--- a/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
+++ b/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Mindscape.Raygun4Net.WebApi\WebClientHelper.cs">
+      <Link>WebClientHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\Breadcrumbs\DefaultBreadcrumbStorage.cs">
       <Link>Breadcrumbs\DefaultBreadcrumbStorage.cs</Link>
     </Compile>

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -605,7 +605,7 @@ namespace Mindscape.Raygun4Net
         {
           try
           {
-            Send(message);
+           WebClientHelper.Send(message,_apiKey, ProxyCredentials);
           }
           catch (Exception ex)
           {
@@ -622,52 +622,6 @@ namespace Mindscape.Raygun4Net
         }
       }
     }
-
-    private void Send(string message)
-    {
-      if (ValidateApiKey())
-      {
-        using (var client = CreateWebClient())
-        {
-          client.UploadString(RaygunSettings.Settings.ApiEndpoint, message);
-        }
-      }
-    }
-
-    protected WebClient CreateWebClient()
-    {
-      var client = new WebClient();
-      client.Headers.Add("X-ApiKey", _apiKey);
-      client.Headers.Add("content-type", "application/json; charset=utf-8");
-      client.Encoding = System.Text.Encoding.UTF8;
-
-      if (WebProxy != null)
-      {
-        client.Proxy = WebProxy;
-      }
-      else if (WebRequest.DefaultWebProxy != null)
-      {
-        Uri proxyUri = WebRequest.DefaultWebProxy.GetProxy(new Uri(RaygunSettings.Settings.ApiEndpoint.ToString()));
-
-        if (proxyUri != null && proxyUri.AbsoluteUri != RaygunSettings.Settings.ApiEndpoint.ToString())
-        {
-          client.Proxy = new WebProxy(proxyUri, false);
-
-          if (ProxyCredentials == null)
-          {
-            client.UseDefaultCredentials = true;
-            client.Proxy.Credentials = CredentialCache.DefaultCredentials;
-          }
-          else
-          {
-            client.UseDefaultCredentials = false;
-            client.Proxy.Credentials = ProxyCredentials;
-          }
-        }
-      }
-      return client;
-    }
-
     private void SaveMessage(string message)
     {
       try
@@ -745,7 +699,7 @@ namespace Mindscape.Raygun4Net
                   string text = reader.ReadToEnd();
                   try
                   {
-                    Send(text);
+                    WebClientHelper.Send(text,_apiKey, ProxyCredentials);
                   }
                   catch
                   {

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using Mindscape.Raygun4Net.Messages;
@@ -609,8 +610,15 @@ namespace Mindscape.Raygun4Net
           }
           catch (Exception ex)
           {
-            SaveMessage(message);
-            System.Diagnostics.Trace.WriteLine(string.Format("Error Logging Exception to Raygun.io {0}", ex.Message));
+            try
+            {
+              SaveMessage(message);
+              Trace.WriteLine(string.Format("Error Logging Exception to Raygun.io {0}", ex.Message));
+            }
+            catch
+            {
+              //ignored
+            }
 
             if (RaygunSettings.Settings.ThrowOnError)
             {


### PR DESCRIPTION
HttpWeblcient is instantiated too many times and causes network flooding with DNS resolutions.
Fix: Implemented singleton Client.
Writing to the System.Diagnostics.Trace some times fails and crashes the app.
Wrapped try trace writer in a try-catch block