### PR TITLE
Implement HTTP request instructions for manually sent excpetions

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,21 @@ Note that you may experience errors if you include the HTTP Module in the `<syst
 The HTTP module is only required if you are using MVC or regular ASP.NET - all WebApi errors are caught using
 `RaygunWebApiClient.Attach`.
 
+To include the HTTP request details, pass in the current request message to the client SetCurrentHTTPRequest when manually sending exceptions.
+
+```csharp
+try
+{
+  // Do something here that might go wrong
+}
+catch (Exception e)
+{
+  var client = new RaygunWebApiClient();
+  client.SetCurrentHttpRequest(ActionContext.Request);
+  client.SendInBackground(e);
+}
+```
+
 The Mvc and WebApi NuGet packages can be installed in the same project safely.
 
 ### WPF

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Note that you may experience errors if you include the HTTP Module in the `<syst
 The HTTP module is only required if you are using MVC or regular ASP.NET - all WebApi errors are caught using
 `RaygunWebApiClient.Attach`.
 
-To include the HTTP request details, pass in the current request message to the client SetCurrentHTTPRequest when manually sending exceptions.
+To include the HTTP request details, pass in the current request message to the client's SetCurrentHTTPRequest method when manually sending exceptions.
 
 ```csharp
 try


### PR DESCRIPTION
Overview
---

This PR is to implement information within the README.md about sending further information about HTTP request details if you are manually sending exceptions. This is so when future customers won't have to contact us via Intercom as well