### PR TITLE
Use Static HttpClient in .NetCore Projects

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -7,7 +7,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting ASP.Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.AspNetCore</PackageId>
-    <PackageVersion>6.2.1</PackageVersion>
+    <PackageVersion>6.2.1-beta1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -7,7 +7,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting ASP.Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.AspNetCore</PackageId>
-    <PackageVersion>6.2.0</PackageVersion>
+    <PackageVersion>6.2.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.2.0")]
-[assembly: AssemblyFileVersion("6.2.0")]
+[assembly: AssemblyVersion("6.2.1")]
+[assembly: AssemblyFileVersion("6.2.1")]

--- a/Mindscape.Raygun4Net.AspNetCore/readme.txt
+++ b/Mindscape.Raygun4Net.AspNetCore/readme.txt
@@ -13,7 +13,7 @@ The main classes can be found in the Mindscape.Raygun4Net namespace.
 Usage
 ======
 
-In your project.json file, add "Mindscape.Raygun4Net.AspNetCore": "6.2.0" to your dependencies.
+In your project.json file, add "Mindscape.Raygun4Net.AspNetCore": "6.2.1" to your dependencies.
 
 Run dotnet.exe restore or restore packages within Visual Studio to download the package.
 
@@ -39,13 +39,13 @@ try
 catch (Exception e)
 {
   new RaygunClient("YOUR_APP_API_KEY").SendInBackground(e);
-} 
+}
 
 Configure RaygunClient or settings in RaygunAspNetCoreMiddleware
 ================================================================
 
-The AddRaygun method has an overload that takes a RaygunMiddlewareSettings object. 
-These settings control the middleware (not to be confused with RaygunSettings which are the common settings we use across all of our .NET providers). 
+The AddRaygun method has an overload that takes a RaygunMiddlewareSettings object.
+These settings control the middleware (not to be confused with RaygunSettings which are the common settings we use across all of our .NET providers).
 Currently there's just one property on it, ClientProvider. This gives you a hook into the loading of RaygunSettings and the construction of the RaygunAspNetCoreClient used to send errors.
 
 For example, say you want to set user details on your error reports. You'd create a custom client provider like this:
@@ -174,7 +174,7 @@ Placing * before, after or at both ends of a key will perform an ends-with, star
 For example, IgnoreFormFieldNames: ["*password*"] will cause Raygun to ignore all form fields that contain "password" anywhere in the name.
 These options are not case sensitive.
 
-Note: The IgnoreSensitiveFieldNames will be applied to ALL fields in the RaygunRequestMessage. 
+Note: The IgnoreSensitiveFieldNames will be applied to ALL fields in the RaygunRequestMessage.
 
 We provide extra options for removing sensitive data from the request raw data. This comes in the form of filters as implemented by the IRaygunDataFilter interface.
 These filters read the raw data and strip values whose keys match those found in the RaygunSettings IgnoreSensitiveFieldNames property.

--- a/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunClientMessage.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunClientMessage.cs
@@ -5,10 +5,10 @@
     public RaygunClientMessage()
     {
       Name = "Raygun4Net.NetCore";
-      Version = "6.2.0";
+      Version = "6.2.1";
       ClientUrl = @"https://github.com/MindscapeHQ/raygun4net";
     }
-    
+
     public string Name { get; set; }
 
     public string Version { get; set; }

--- a/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
+++ b/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
@@ -8,7 +8,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library .NetCore applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore.Common</PackageId>
-    <PackageVersion>6.2.0</PackageVersion>
+    <PackageVersion>6.2.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
+++ b/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
@@ -8,7 +8,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library .NetCore applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore.Common</PackageId>
-    <PackageVersion>6.2.1</PackageVersion>
+    <PackageVersion>6.2.1-beta1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -14,7 +14,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting .Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore</PackageId>
-    <PackageVersion>6.2.1</PackageVersion>
+    <PackageVersion>6.2.1-beta1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -14,7 +14,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting .Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore</PackageId>
-    <PackageVersion>6.2.0</PackageVersion>
+    <PackageVersion>6.2.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.NetCore/Properties/AssemblyVersionInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.2.0")]
-[assembly: AssemblyFileVersion("6.2.0")]
+[assembly: AssemblyVersion("6.2.1")]
+[assembly: AssemblyFileVersion("6.2.1")]

--- a/Mindscape.Raygun4Net.NetCore/readme.txt
+++ b/Mindscape.Raygun4Net.NetCore/readme.txt
@@ -13,7 +13,7 @@ The main classes can be found in the Mindscape.Raygun4Net namespace.
 Usage
 =====
 
-In your project file, add "Mindscape.Raygun4Net.NetCore": "6.2.0" to your dependencies.
+In your project file, add "Mindscape.Raygun4Net.NetCore": "6.2.1" to your dependencies.
 
 Run dotnet.exe restore or restore packages within Visual Studio to download the package.
 
@@ -26,7 +26,7 @@ try
 catch (Exception e)
 {
   new RaygunClient("YOUR_APP_API_KEY").SendInBackground(e);
-} 
+}
 
 Additional configuration options and features
 =============================================


### PR DESCRIPTION
# Overview 🚉 
Previously the .Net Core projects were new'ing up an HttpClient on every Send call. This was potentially causing connection pool exhaustion. The HttpClient class is designed to be a single instance that will manage it's connections internally, therefore a static instance makes sense. There could be issues around out of date DNS changes, so long term we will look to use an HttpClientFactory or something similar.

# Changes 🔧 
- Create static HttpClient in RaygunClientBase
- Use static client instead of new'd up client in using statement