### PR TITLE
Add SendInBackground overload to NetCore projects to support sending an Exception with a RaygunIdentifierMessage

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
@@ -241,7 +241,7 @@ namespace Mindscape.Raygun4Net.AspNetCore
             {
                 _currentRequestMessage.Value = currentRequestMessage;
                 _currentResponseMessage.Value = currentResponseMessage;
-                await StripAndSend(exception, tags, userCustomData, null);
+                await StripAndSend(exception, tags, userCustomData, userInfo);
             });
             FlagAsSent(exception);
             await task;

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
@@ -227,17 +227,6 @@ namespace Mindscape.Raygun4Net.AspNetCore
     /// <param name="exception">The exception to deliver.</param>
     /// <param name="tags">A list of strings associated with the message.</param>
     /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
-    public Task SendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData)
-    {
-        return SendInBackground(exception, tags, userCustomData, null);
-    }
-
-    /// <summary>
-    /// Asynchronously transmits an exception to Raygun.
-    /// </summary>
-    /// <param name="exception">The exception to deliver.</param>
-    /// <param name="tags">A list of strings associated with the message.</param>
-    /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
     /// <param name="userInfo">Information about the user including the identity string.</param>
     public override async Task SendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo)
     {

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
@@ -227,24 +227,36 @@ namespace Mindscape.Raygun4Net.AspNetCore
     /// <param name="exception">The exception to deliver.</param>
     /// <param name="tags">A list of strings associated with the message.</param>
     /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
-    public override async Task SendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData)
+    public Task SendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData)
     {
-      if (CanSend(exception))
-      {
-        // We need to process the Request on the current thread,
-        // otherwise it will be disposed while we are using it on the other thread.
-        RaygunRequestMessage currentRequestMessage = await BuildRequestMessage();
-        RaygunResponseMessage currentResponseMessage = BuildResponseMessage();
+        return SendInBackground(exception, tags, userCustomData, null);
+    }
 
-        var task = Task.Run(async () =>
+    /// <summary>
+    /// Asynchronously transmits an exception to Raygun.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
+    /// <param name="userInfo">Information about the user including the identity string.</param>
+    public override async Task SendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo)
+    {
+        if (CanSend(exception))
         {
-          _currentRequestMessage.Value = currentRequestMessage;
-          _currentResponseMessage.Value = currentResponseMessage;
-          await StripAndSend(exception, tags, userCustomData);
-        });
-        FlagAsSent(exception);
-        await task;
-      }
+            // We need to process the Request on the current thread,
+            // otherwise it will be disposed while we are using it on the other thread.
+            RaygunRequestMessage currentRequestMessage = await BuildRequestMessage();
+            RaygunResponseMessage currentResponseMessage = BuildResponseMessage();
+
+            var task = Task.Run(async () =>
+            {
+                _currentRequestMessage.Value = currentRequestMessage;
+                _currentResponseMessage.Value = currentResponseMessage;
+                await StripAndSend(exception, tags, userCustomData, null);
+            });
+            FlagAsSent(exception);
+            await task;
+        }
     }
 
     private async Task<RaygunRequestMessage> BuildRequestMessage()
@@ -267,7 +279,7 @@ namespace Mindscape.Raygun4Net.AspNetCore
       return this;
     }
 
-    protected override async Task<RaygunMessage> BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData)
+    protected override async Task<RaygunMessage> BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfoMessage)
     {
       var message = RaygunMessageBuilder.New(GetSettings())
         .SetResponseDetails(_currentResponseMessage.Value)
@@ -279,7 +291,7 @@ namespace Mindscape.Raygun4Net.AspNetCore
         .SetVersion(ApplicationVersion)
         .SetTags(tags)
         .SetUserCustomData(userCustomData)
-        .SetUser(UserInfo ?? (!String.IsNullOrEmpty(User) ? new RaygunIdentifierMessage(User) : null))
+        .SetUser(userInfoMessage ?? UserInfo ?? (!String.IsNullOrEmpty(User) ? new RaygunIdentifierMessage(User) : null))
         .Build();
 
       var customGroupingKey = await OnCustomGroupingKey(exception, message);


### PR DESCRIPTION
Resolves #428.

Adds a `SendInBackground` overload to the NetCore packages which supports sending an `Exception` with a `RaygunIdentifierMessage`.

This mirrors what is currently available in the `Mindscape.Raygun4Net` package:

https://github.com/MindscapeHQ/raygun4net/blob/d59749c03519a5210409408a7aa2bb1a122c5e25/Mindscape.Raygun4Net/RaygunClient.cs#L289-L296