### PR TITLE
[CR-204] Have the SendingMessage event include the original exception 

### DIFF
--- a/AssemblyVersionInfo.cs
+++ b/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.10.2.0")]
-[assembly: AssemblyFileVersion("5.10.2.0")]
+[assembly: AssemblyVersion("5.11.0.0")]
+[assembly: AssemblyFileVersion("5.11.0.0")]

--- a/Mindscape.Raygun4Net.ClientProfile.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.ClientProfile.Tests/RaygunClientTests.cs
@@ -297,7 +297,7 @@ namespace Mindscape.Raygun4Net.Tests
     [Test]
     public void NoHandlerSendsAll()
     {
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -310,7 +310,7 @@ namespace Mindscape.Raygun4Net.Tests
         filterCalled = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filterCalled);
     }
 
@@ -321,7 +321,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -341,7 +341,7 @@ namespace Mindscape.Raygun4Net.Tests
         filter2Called = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filter1Called);
       Assert.IsTrue(filter2Called);
     }
@@ -357,7 +357,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -371,7 +371,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -385,7 +385,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -399,7 +399,7 @@ namespace Mindscape.Raygun4Net.Tests
         e.Message.Details.Error.Message = "Custom error message";
       };
 
-      Assert.IsTrue(_client.ExposeOnSendingMessage(message));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(message, _exception));
       Assert.AreEqual("Custom error message", message.Details.Error.Message);
     }
 

--- a/Mindscape.Raygun4Net.ClientProfile/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.ClientProfile/RaygunClient.cs
@@ -140,7 +140,7 @@ namespace Mindscape.Raygun4Net
     {
       if (CanSend(exception))
       {
-        Send(BuildMessage(exception, tags, userCustomData, userInfo, null));
+        Send(BuildMessage(exception, tags, userCustomData, userInfo, null), exception);
         FlagAsSent(exception);
       }
     }
@@ -191,7 +191,7 @@ namespace Mindscape.Raygun4Net
         {
           try
           {
-            Send(BuildMessage(exception, tags, userCustomData, userInfo, currentTime));
+            Send(BuildMessage(exception, tags, userCustomData, userInfo, currentTime), exception);
           }
           catch (Exception)
           {
@@ -212,9 +212,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void SendInBackground(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception that generated the RaygunMessage</param>
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
     {
-      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage));
+      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }
 
     protected RaygunMessage BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData)
@@ -266,9 +267,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public override void Send(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception that generated the RaygunMessage</param>
+    public override void Send(RaygunMessage raygunMessage, Exception exception)
     {
-      bool canSend = OnSendingMessage(raygunMessage);
+      bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)
       {
         string message = null;

--- a/Mindscape.Raygun4Net.ClientProfile/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.ClientProfile/RaygunClient.cs
@@ -93,7 +93,7 @@ namespace Mindscape.Raygun4Net
         _wrapperExceptions.Remove(wrapper);
       }
     }
-    
+
     /// <summary>
     /// Transmits an exception to Raygun.io synchronously, using the version number of the originating assembly.
     /// </summary>
@@ -268,7 +268,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception that generated the RaygunMessage</param>
-    public override void Send(RaygunMessage raygunMessage, Exception exception)
+    public override void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)

--- a/Mindscape.Raygun4Net.Core.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Core.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Core.Signed</id>
-    <version>5.10.2</version>
+    <version>5.11.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Core.nuspec
+++ b/Mindscape.Raygun4Net.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Core</id>
-    <version>5.10.2</version>
+    <version>5.11.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
+++ b/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
@@ -60,9 +60,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\AssemblyVersionInfo.cs">
-      <Link>Properties\AssemblyVersionInfo.cs</Link>
-    </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\Attributes\DoNotProfileAttribute.cs">
       <Link>Attributes\DoNotProfileAttribute.cs</Link>
     </Compile>
@@ -135,6 +132,7 @@
     <Compile Include="..\Mindscape.Raygun4Net\Filters\RaygunKeyValuePairDataFilter.cs">
       <Link>Filters\RaygunKeyValuePairDataFilter.cs</Link>
     </Compile>
+    <Compile Include="Properties\AssemblyVersionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Filters\" />

--- a/Mindscape.Raygun4Net.Core/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.Core/Properties/AssemblyVersionInfo.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("5.11.0.0")]
+[assembly: AssemblyFileVersion("5.11.0.0")]

--- a/Mindscape.Raygun4Net.Mvc.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc.Signed</id>
-    <version>5.10.3</version>
+    <version>5.11.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Mvc.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.Signed.nuspec
@@ -12,7 +12,7 @@
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
     <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.10.2" />
+      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.11.0" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.Mvc.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.nuspec
@@ -12,7 +12,7 @@
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
     <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core" version="5.10.2" />
+      <dependency id="Mindscape.Raygun4Net.Core" version="5.11.0" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.Mvc.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc</id>
-    <version>5.10.3</version>
+    <version>5.11.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Mvc/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.Mvc/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.10.3.0")]
-[assembly: AssemblyFileVersion("5.10.3.0")]
+[assembly: AssemblyVersion("5.11.0.0")]
+[assembly: AssemblyFileVersion("5.11.0.0")]

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>Mindscape.Raygun4Net.NetCore</AssemblyName>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
-    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Sign</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/Mindscape.Raygun4Net.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Signed</id>
-    <version>5.10.2</version>
+    <version>5.11.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net.Tests/Model/FakeRaygunClient.cs
@@ -33,9 +33,9 @@ namespace Mindscape.Raygun4Net.Tests
       return ValidateApiKey();
     }
 
-    public bool ExposeOnSendingMessage(RaygunMessage raygunMessage)
+    public bool ExposeOnSendingMessage(RaygunMessage raygunMessage, Exception exception)
     {
-      return OnSendingMessage(raygunMessage);
+      return OnSendingMessage(raygunMessage, exception);
     }
 
     public bool ExposeCanSend(Exception exception)

--- a/Mindscape.Raygun4Net.Tests/RaygunClientBaseTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunClientBaseTests.cs
@@ -55,8 +55,8 @@ namespace Mindscape.Raygun4Net.Tests
         throw new Exception("Oops...");
       };
 
-      Assert.That(() => client.ExposeOnSendingMessage(new RaygunMessage()), Throws.Nothing);
-      Assert.IsTrue(client.ExposeOnSendingMessage(new RaygunMessage()));
+      Assert.That(() => client.ExposeOnSendingMessage(new RaygunMessage(), new Exception()), Throws.Nothing);
+      Assert.IsTrue(client.ExposeOnSendingMessage(new RaygunMessage(), new Exception()));
     }
   }
 }

--- a/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunClientTests.cs
@@ -305,7 +305,7 @@ namespace Mindscape.Raygun4Net.Tests
     [Test]
     public void NoHandlerSendsAll()
     {
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -318,7 +318,7 @@ namespace Mindscape.Raygun4Net.Tests
         filterCalled = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filterCalled);
     }
 
@@ -329,7 +329,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -349,7 +349,7 @@ namespace Mindscape.Raygun4Net.Tests
         filter2Called = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filter1Called);
       Assert.IsTrue(filter2Called);
     }
@@ -365,7 +365,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -379,7 +379,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -393,7 +393,7 @@ namespace Mindscape.Raygun4Net.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -407,7 +407,7 @@ namespace Mindscape.Raygun4Net.Tests
         e.Message.Details.Error.Message = "Custom error message";
       };
 
-      Assert.IsTrue(_client.ExposeOnSendingMessage(message));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(message, _exception));
       Assert.AreEqual("Custom error message", message.Details.Error.Message);
     }
 

--- a/Mindscape.Raygun4Net.WebApi.Signed.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.WebApi.Signed</id>
-    <version>5.10.3</version>
+    <version>5.11.0</version>
     <title>Raygun for ASP.NET Web API</title>
     <authors>Raygun</authors>
     <owners />
@@ -13,7 +13,7 @@
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
     <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.10.2" />
+      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.11.0" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.WebApi.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.WebApi</id>
-    <version>5.10.3</version>
+    <version>5.11.0</version>
     <title>Raygun for ASP.NET Web API</title>
     <authors>Raygun</authors>
     <owners />
@@ -13,7 +13,7 @@
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
     <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core" version="5.10.2" />
+      <dependency id="Mindscape.Raygun4Net.Core" version="5.11.0" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.WebApi/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.WebApi/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.10.3.0")]
-[assembly: AssemblyFileVersion("5.10.3.0")]
+[assembly: AssemblyVersion("5.11.0.0")]
+[assembly: AssemblyFileVersion("5.11.0.0")]

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -19,19 +19,19 @@ namespace Mindscape.Raygun4Net.WebApi
   public class RaygunWebApiClient : RaygunClientBase
   {
     internal const string UnhandledExceptionTag = "UnhandledException";
-    
+
     protected readonly RaygunRequestMessageOptions _requestMessageOptions = new RaygunRequestMessageOptions();
     private readonly List<Type> _wrapperExceptions = new List<Type>();
 
     private readonly ThreadLocal<HttpRequestMessage> _currentWebRequest = new ThreadLocal<HttpRequestMessage>(() => null);
     private readonly ThreadLocal<RaygunRequestMessage> _currentRequestMessage = new ThreadLocal<RaygunRequestMessage>(() => null);
-    
+
     private readonly string _apiKey;
 
     private static RaygunWebApiExceptionFilter _exceptionFilter;
     private static RaygunWebApiActionFilter _actionFilter;
     private static RaygunWebApiDelegatingHandler _delegatingHandler;
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RaygunClientBase" /> class.
     /// Uses the ApiKey specified in the config file.
@@ -59,7 +59,7 @@ namespace Mindscape.Raygun4Net.WebApi
     public RaygunWebApiClient(string apiKey)
     {
       _apiKey = apiKey;
-      
+
       ApplicationVersion = RaygunSettings.Settings.ApplicationVersion;
       if (string.IsNullOrEmpty(ApplicationVersion))
       {
@@ -68,7 +68,7 @@ namespace Mindscape.Raygun4Net.WebApi
         // or else we will not be getting the user's library but our own Raygun4Net library.
         ApplicationVersion = Assembly.GetCallingAssembly()?.GetName()?.Version?.ToString();
       }
-      
+
       Init();
     }
 
@@ -86,7 +86,7 @@ namespace Mindscape.Raygun4Net.WebApi
         // or else we will not be getting the user's library but our own Raygun4Net library.
         appVersion = Assembly.GetCallingAssembly()?.GetName()?.Version?.ToString();
       }
-      
+
       AttachInternal(config, null, appVersion);
     }
 
@@ -105,7 +105,7 @@ namespace Mindscape.Raygun4Net.WebApi
         // or else we will not be getting the user's library but our own Raygun4Net library.
         appVersion = Assembly.GetCallingAssembly()?.GetName()?.Version?.ToString();
       }
-      
+
       if (generateRaygunClient != null)
       {
         AttachInternal(config, message => generateRaygunClient(), appVersion);
@@ -145,7 +145,7 @@ namespace Mindscape.Raygun4Net.WebApi
       string appVersion)
     {
       Detach(config);
-      
+
       if (RaygunSettings.Settings.IsRawDataIgnored == false)
       {
         _delegatingHandler = new RaygunWebApiDelegatingHandler();
@@ -220,9 +220,9 @@ namespace Mindscape.Raygun4Net.WebApi
         _actionFilter = null;
       }
     }
-    
+
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="apiKey">The API key.</param>
     /// <param name="version">The application version.</param>
@@ -444,7 +444,7 @@ namespace Mindscape.Raygun4Net.WebApi
 
     /// <summary>
     /// Add an <see cref="IRaygunDataFilter"/> implementation to be used when capturing the raw data
-    /// of a HTTP request. This filter will be passed the request raw data and is expected to remove 
+    /// of a HTTP request. This filter will be passed the request raw data and is expected to remove
     /// or replace values whose keys are found in the list supplied to the Filter method.
     /// </summary>
     /// <param name="filter">Custom raw data filter implementation.</param>
@@ -661,7 +661,7 @@ namespace Mindscape.Raygun4Net.WebApi
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception used to generate the RaygunMessage</param>
-    public override void Send(RaygunMessage raygunMessage, Exception exception)
+    public override void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       try
       {

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -540,9 +540,10 @@ namespace Mindscape.Raygun4Net.WebApi
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void SendInBackground(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception used to generate the RaygunMessage</param>
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
     {
-      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage));
+      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }
 
     internal void FlagExceptionAsSent(Exception exception)
@@ -596,7 +597,7 @@ namespace Mindscape.Raygun4Net.WebApi
     {
       foreach (Exception e in StripWrapperExceptions(exception))
       {
-        Send(BuildMessage(e, tags, userCustomData, currentTime));
+        Send(BuildMessage(e, tags, userCustomData, currentTime), exception);
       }
     }
 
@@ -659,11 +660,12 @@ namespace Mindscape.Raygun4Net.WebApi
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public override void Send(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception used to generate the RaygunMessage</param>
+    public override void Send(RaygunMessage raygunMessage, Exception exception)
     {
       try
       {
-        bool canSend = OnSendingMessage(raygunMessage) && CanSend(raygunMessage);
+        bool canSend = OnSendingMessage(raygunMessage, exception) && CanSend(raygunMessage);
         if (canSend)
         {
           var message = SimpleJson.SerializeObject(raygunMessage);

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -541,7 +541,7 @@ namespace Mindscape.Raygun4Net.WebApi
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception used to generate the RaygunMessage</param>
-    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception = null)
     {
       ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }

--- a/Mindscape.Raygun4Net.WinRT.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net.WinRT.Tests/Model/FakeRaygunClient.cs
@@ -23,9 +23,9 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
       return BuildMessage(exception, tags, userCustomData);
     }
 
-    public bool ExposeOnSendingMessage(RaygunMessage raygunMessage)
+    public bool ExposeOnSendingMessage(RaygunMessage raygunMessage, Exception exception)
     {
-      return OnSendingMessage(raygunMessage);
+      return OnSendingMessage(raygunMessage, exception);
     }
 
     public IEnumerable<Exception> ExposeStripWrapperExceptions(Exception exception)

--- a/Mindscape.Raygun4Net.WinRT.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net.WinRT.Tests/RaygunClientTests.cs
@@ -22,7 +22,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
     [Test]
     public void NoHandlerSendsAll()
     {
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -35,7 +35,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
         filterCalled = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filterCalled);
     }
 
@@ -46,7 +46,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -66,7 +66,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
         filter2Called = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filter1Called);
       Assert.IsTrue(filter2Called);
     }
@@ -82,7 +82,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -96,7 +96,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
       {
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -110,7 +110,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -124,7 +124,7 @@ namespace Mindscape.Raygun4Net.WinRT.Tests
         e.Message.Details.Error.Message = "Custom error message";
       };
 
-      Assert.IsTrue(_client.ExposeOnSendingMessage(message));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(message, _exception));
       Assert.AreEqual("Custom error message", message.Details.Error.Message);
     }
 

--- a/Mindscape.Raygun4Net.WinRT/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.WinRT/RaygunClient.cs
@@ -53,16 +53,18 @@ namespace Mindscape.Raygun4Net
     private bool _handlingRecursiveErrorSending;
 
     // Returns true if the message can be sent, false if the sending is canceled.
-    protected bool OnSendingMessage(RaygunMessage raygunMessage)
+    protected bool OnSendingMessage(RaygunMessage raygunMessage, Exception exception)
     {
       bool result = true;
 
       if (!_handlingRecursiveErrorSending)
       {
         EventHandler<RaygunSendingMessageEventArgs> handler = SendingMessage;
+
         if (handler != null)
         {
-          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage);
+          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage, exception);
+
           try
           {
             handler(this, args);
@@ -232,11 +234,11 @@ namespace Mindscape.Raygun4Net
       StripAndSend(exception, tags, userCustomData);
     }
 
-    public async void Send(RaygunMessage raygunMessage)
+    public async void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       if (ValidateApiKey())
       {
-        bool canSend = OnSendingMessage(raygunMessage);
+        bool canSend = OnSendingMessage(raygunMessage, exception);
         if (canSend)
         {
           HttpClientHandler handler = new HttpClientHandler {UseDefaultCredentials = true};

--- a/Mindscape.Raygun4Net.WinRT/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.WinRT/RaygunClient.cs
@@ -53,7 +53,7 @@ namespace Mindscape.Raygun4Net
     private bool _handlingRecursiveErrorSending;
 
     // Returns true if the message can be sent, false if the sending is canceled.
-    protected bool OnSendingMessage(RaygunMessage raygunMessage, Exception exception)
+    protected bool OnSendingMessage(RaygunMessage raygunMessage, Exception exception = null)
     {
       bool result = true;
 

--- a/Mindscape.Raygun4Net.WindowsStore.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net.WindowsStore.Tests/Model/FakeRaygunClient.cs
@@ -23,9 +23,9 @@ namespace Mindscape.Raygun4Net.WindowsStore.Tests
       return BuildMessage(exception, tags, userCustomData);
     }
 
-    public bool ExposeOnSendingMessage(RaygunMessage raygunMessage)
+    public bool ExposeOnSendingMessage(RaygunMessage raygunMessage, [Optional] Exception exception)
     {
-      return OnSendingMessage(raygunMessage);
+      return OnSendingMessage(raygunMessage, exception);
     }
 
     public IEnumerable<Exception> ExposeStripWrapperExceptions(Exception exception)

--- a/Mindscape.Raygun4Net.WindowsStore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.WindowsStore/RaygunClient.cs
@@ -71,7 +71,7 @@ namespace Mindscape.Raygun4Net
     private bool _handlingRecursiveErrorSending;
 
     // Returns true if the message can be sent, false if the sending is canceled.
-    protected bool OnSendingMessage(RaygunMessage raygunMessage, Exception exception)
+    protected bool OnSendingMessage(RaygunMessage raygunMessage, Exception exception = null)
     {
       bool result = true;
 
@@ -279,7 +279,8 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public async Task SendAsync(RaygunMessage raygunMessage, Exception exception)
+    /// <param name="exception">The original exception object that the <paramref name="raygunMessage"/> is based upon.</param>
+    public async Task SendAsync(RaygunMessage raygunMessage, Exception exception = null)
     {
       await SendOrSave(raygunMessage, exception);
     }
@@ -329,7 +330,8 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void Send(RaygunMessage raygunMessage, Exception exception)
+    /// <param name="exception">The original exception object that the <paramref name="raygunMessage"/> is based upon.</param>
+    public void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       SendOrSave(raygunMessage, exception).Wait(3000);
     }

--- a/Mindscape.Raygun4Net.WindowsStore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.WindowsStore/RaygunClient.cs
@@ -71,7 +71,7 @@ namespace Mindscape.Raygun4Net
     private bool _handlingRecursiveErrorSending;
 
     // Returns true if the message can be sent, false if the sending is canceled.
-    protected bool OnSendingMessage(RaygunMessage raygunMessage)
+    protected bool OnSendingMessage(RaygunMessage raygunMessage, Exception exception)
     {
       bool result = true;
 
@@ -80,7 +80,7 @@ namespace Mindscape.Raygun4Net
         EventHandler<RaygunSendingMessageEventArgs> handler = SendingMessage;
         if (handler != null)
         {
-          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage);
+          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage, exception);
           try
           {
             handler(this, args);
@@ -279,9 +279,9 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public async Task SendAsync(RaygunMessage raygunMessage)
+    public async Task SendAsync(RaygunMessage raygunMessage, Exception exception)
     {
-      await SendOrSave(raygunMessage);
+      await SendOrSave(raygunMessage, exception);
     }
 
     /// <summary>
@@ -329,9 +329,9 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void Send(RaygunMessage raygunMessage)
+    public void Send(RaygunMessage raygunMessage, Exception exception)
     {
-      SendOrSave(raygunMessage).Wait(3000);
+      SendOrSave(raygunMessage, exception).Wait(3000);
     }
 
     private bool InternetAvailable()
@@ -345,11 +345,11 @@ namespace Mindscape.Raygun4Net
       return internetAvailable;
     }
 
-    private async Task SendOrSave(RaygunMessage raygunMessage)
+    private async Task SendOrSave(RaygunMessage raygunMessage, Exception exception)
     {
       if (ValidateApiKey())
       {
-        bool canSend = OnSendingMessage(raygunMessage);
+        bool canSend = OnSendingMessage(raygunMessage, exception);
         if (canSend)
         {
           try
@@ -551,7 +551,7 @@ namespace Mindscape.Raygun4Net
       var currentTime = DateTime.UtcNow;
       foreach (Exception e in StripWrapperExceptions(exception))
       {
-        Send(BuildMessage(e, tags, userCustomData, currentTime));
+        Send(BuildMessage(e, tags, userCustomData, currentTime), exception);
       }
     }
 
@@ -561,7 +561,7 @@ namespace Mindscape.Raygun4Net
       var currentTime = DateTime.UtcNow;
       foreach (Exception e in StripWrapperExceptions(exception))
       {
-        tasks.Add(SendAsync(BuildMessage(e, tags, userCustomData, currentTime)));
+        tasks.Add(SendAsync(BuildMessage(e, tags, userCustomData, currentTime), exception));
       }
       await Task.WhenAll(tasks);
     }

--- a/Mindscape.Raygun4Net.Xamarin.Android/Mindscape.Raygun4Net.Xamarin.Android.csproj
+++ b/Mindscape.Raygun4Net.Xamarin.Android/Mindscape.Raygun4Net.Xamarin.Android.csproj
@@ -78,14 +78,8 @@
     <Compile Include="..\Mindscape.Raygun4Net\Messages\RaygunMessage.cs">
       <Link>Messages\RaygunMessage.cs</Link>
     </Compile>
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunClientBase.cs">
-      <Link>RaygunClientBase.cs</Link>
-    </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\RaygunCustomGroupingKeyEventArgs.cs">
       <Link>RaygunCustomGroupingKeyEventArgs.cs</Link>
-    </Compile>
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunSendingMessageEventArgs.cs">
-      <Link>RaygunSendingMessageEventArgs.cs</Link>
     </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\SimpleJson.cs">
       <Link>SimpleJson.cs</Link>
@@ -114,6 +108,8 @@
     <Compile Include="RaygunFileManager.cs" />
     <Compile Include="RaygunFile.cs" />
     <Compile Include="RaygunResponseStatusCode.cs" />
+    <Compile Include="RaygunClientBase.cs" />
+    <Compile Include="RaygunSendingMessageEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/Mindscape.Raygun4Net.Xamarin.Android/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Android/RaygunClientBase.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Net;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net
+{
+  public abstract class RaygunClientBase
+  {
+    protected internal const string SentKey = "AlreadySentByRaygun";
+
+    /// <summary>
+    /// Gets or sets the user identity string.
+    /// </summary>
+    public virtual string User { get; set; }
+
+    /// <summary>
+    /// Gets or sets information about the user including the identity string.
+    /// </summary>
+    public virtual RaygunIdentifierMessage UserInfo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the context identifier defining a scope under which errors are related
+    /// </summary>
+    public string ContextId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a custom application version identifier for all error messages sent to the Raygun endpoint.
+    /// </summary>
+    public string ApplicationVersion { get; set; }
+
+    protected virtual bool CanSend(Exception exception)
+    {
+      return exception == null || exception.Data == null || !exception.Data.Contains(SentKey) || false.Equals(exception.Data[SentKey]);
+    }
+
+    protected void FlagAsSent(Exception exception)
+    {
+      if (exception != null && exception.Data != null)
+      {
+        try
+        {
+          Type[] genericTypes = exception.Data.GetType().GetGenericArguments();
+          if (genericTypes.Length == 0 || genericTypes[0].IsAssignableFrom(typeof(string)))
+          {
+            exception.Data[SentKey] = true;
+          }
+        }
+        catch (Exception ex)
+        {
+          System.Diagnostics.Debug.WriteLine(String.Format("Failed to flag exception as sent: {0}", ex.Message));
+        }
+      }
+    }
+
+    /// <summary>
+    /// Raised just before a message is sent. This can be used to make final adjustments to the <see cref="RaygunMessage"/>, or to cancel the send.
+    /// </summary>
+    public event EventHandler<RaygunSendingMessageEventArgs> SendingMessage;
+
+    private bool _handlingRecursiveErrorSending;
+
+    // Returns true if the message can be sent, false if the sending is canceled.
+    protected bool OnSendingMessage(RaygunMessage raygunMessage)
+    {
+      bool result = true;
+
+      if (!_handlingRecursiveErrorSending)
+      {
+        EventHandler<RaygunSendingMessageEventArgs> handler = SendingMessage;
+
+        if (handler != null)
+        {
+          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage);
+
+          try
+          {
+            handler(this, args);
+          }
+          catch (Exception e)
+          {
+            // Catch and send exceptions that occur in the SendingMessage event handler.
+            // Set the _handlingRecursiveErrorSending flag to prevent infinite errors.
+            _handlingRecursiveErrorSending = true;
+            Send(e);
+            _handlingRecursiveErrorSending = false;
+          }
+
+          result = !args.Cancel;
+        }
+      }
+
+      return result;
+    }
+
+    /// <summary>
+    /// Raised before a message is sent. This can be used to add a custom grouping key to a RaygunMessage before sending it to the Raygun service.
+    /// </summary>
+    public event EventHandler<RaygunCustomGroupingKeyEventArgs> CustomGroupingKey;
+
+    private bool _handlingRecursiveGrouping;
+    protected string OnCustomGroupingKey(Exception exception, RaygunMessage message)
+    {
+      string result = null;
+      if(!_handlingRecursiveGrouping)
+      {
+        var handler = CustomGroupingKey;
+        if(handler != null)
+        {
+          var args = new RaygunCustomGroupingKeyEventArgs(exception, message);
+          try
+          {
+            handler(this, args);
+          }
+          catch (Exception e)
+          {
+            _handlingRecursiveGrouping = true;
+            Send(e);
+            _handlingRecursiveGrouping = false;
+          }
+          result = args.CustomGroupingKey;
+        }
+      }
+      return result;
+    }
+
+    /// <summary>
+    /// Transmits an exception to Raygun.io synchronously.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    public abstract void Send(Exception exception);
+
+    /// <summary>
+    /// Posts a RaygunMessage to the Raygun.io api endpoint.
+    /// </summary>
+    /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
+    /// set to a valid DateTime and as much of the Details property as is available.</param>
+    /// <param name="exception">The original exception used to generate the RaygunMessage</param>
+    public abstract void Send(RaygunMessage raygunMessage);
+  }
+}

--- a/Mindscape.Raygun4Net.Xamarin.Android/RaygunSendingMessageEventArgs.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Android/RaygunSendingMessageEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.ComponentModel;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net
+{
+  /// <summary>
+  /// Can be used to modify the message before sending, or to cancel the send operation.
+  /// </summary>
+  public class RaygunSendingMessageEventArgs : CancelEventArgs
+  {
+    private RaygunMessage _raygunMessage;
+    
+    public RaygunSendingMessageEventArgs(RaygunMessage message)
+    {
+      _raygunMessage = message;
+    }
+
+    public RaygunMessage Message
+    {
+      get { return _raygunMessage; }
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.Xamarin.Mac.Unified/Mindscape.Raygun4Net.Xamarin.Mac.Unified.csproj
+++ b/Mindscape.Raygun4Net.Xamarin.Mac.Unified/Mindscape.Raygun4Net.Xamarin.Mac.Unified.csproj
@@ -71,12 +71,6 @@
     <Compile Include="..\Mindscape.Raygun4Net\IRaygunMessageBuilder.cs">
       <Link>IRaygunMessageBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunClientBase.cs">
-      <Link>RaygunClientBase.cs</Link>
-    </Compile>
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunSendingMessageEventArgs.cs">
-      <Link>RaygunSendingMessageEventArgs.cs</Link>
-    </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\SimpleJson.cs">
       <Link>SimpleJson.cs</Link>
     </Compile>
@@ -115,6 +109,12 @@
     </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\RaygunCustomGroupingKeyEventArgs.cs">
       <Link>RaygunCustomGroupingKeyEventArgs.cs</Link>
+    </Compile>
+    <Compile Include="..\Mindscape.Raygun4Net.Xamarin.Mac\RaygunClientBase.cs">
+      <Link>RaygunClientBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Mindscape.Raygun4Net.Xamarin.Mac\RaygunSendingMessageEventArgs.cs">
+      <Link>RaygunSendingMessageEventArgs.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/Mindscape.Raygun4Net.Xamarin.Mac/Mindscape.Raygun4Net.Xamarin.Mac.csproj
+++ b/Mindscape.Raygun4Net.Xamarin.Mac/Mindscape.Raygun4Net.Xamarin.Mac.csproj
@@ -84,9 +84,6 @@
     <Compile Include="RaygunSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyVersionInfo.cs" />
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunSendingMessageEventArgs.cs">
-      <Link>RaygunSendingMessageEventArgs.cs</Link>
-    </Compile>
     <Compile Include="Builders\RaygunErrorMessageBuilder.cs" />
     <Compile Include="..\Mindscape.Raygun4Net\Builders\RaygunErrorMessageBuilderBase.cs">
       <Link>Builders\RaygunErrorMessageBuilderBase.cs</Link>
@@ -107,15 +104,14 @@
       <Link>Messages\RaygunMessageDetails.cs</Link>
     </Compile>
     <Compile Include="Builders\RaygunEnvironmentMessageBuilder.cs" />
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunClientBase.cs">
-      <Link>RaygunClientBase.cs</Link>
-    </Compile>
     <Compile Include="..\Mindscape.Raygun4Net.Core\Messages\RaygunErrorMessage.cs">
       <Link>Messages\RaygunErrorMessage.cs</Link>
     </Compile>
     <Compile Include="..\Mindscape.Raygun4Net\RaygunCustomGroupingKeyEventArgs.cs">
       <Link>RaygunCustomGroupingKeyEventArgs.cs</Link>
     </Compile>
+    <Compile Include="RaygunClientBase.cs" />
+    <Compile Include="RaygunSendingMessageEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Mindscape.Raygun4Net.Xamarin.Mac/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Mac/RaygunClientBase.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Net;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net
+{
+  public abstract class RaygunClientBase
+  {
+    protected internal const string SentKey = "AlreadySentByRaygun";
+
+    /// <summary>
+    /// Gets or sets the user identity string.
+    /// </summary>
+    public virtual string User { get; set; }
+
+    /// <summary>
+    /// Gets or sets information about the user including the identity string.
+    /// </summary>
+    public virtual RaygunIdentifierMessage UserInfo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the context identifier defining a scope under which errors are related
+    /// </summary>
+    public string ContextId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a custom application version identifier for all error messages sent to the Raygun endpoint.
+    /// </summary>
+    public string ApplicationVersion { get; set; }
+
+    protected virtual bool CanSend(Exception exception)
+    {
+      return exception == null || exception.Data == null || !exception.Data.Contains(SentKey) || false.Equals(exception.Data[SentKey]);
+    }
+
+    protected void FlagAsSent(Exception exception)
+    {
+      if (exception != null && exception.Data != null)
+      {
+        try
+        {
+          Type[] genericTypes = exception.Data.GetType().GetGenericArguments();
+          if (genericTypes.Length == 0 || genericTypes[0].IsAssignableFrom(typeof(string)))
+          {
+            exception.Data[SentKey] = true;
+          }
+        }
+        catch (Exception ex)
+        {
+          System.Diagnostics.Debug.WriteLine(String.Format("Failed to flag exception as sent: {0}", ex.Message));
+        }
+      }
+    }
+
+    /// <summary>
+    /// Raised just before a message is sent. This can be used to make final adjustments to the <see cref="RaygunMessage"/>, or to cancel the send.
+    /// </summary>
+    public event EventHandler<RaygunSendingMessageEventArgs> SendingMessage;
+
+    private bool _handlingRecursiveErrorSending;
+
+    // Returns true if the message can be sent, false if the sending is canceled.
+    protected bool OnSendingMessage(RaygunMessage raygunMessage)
+    {
+      bool result = true;
+
+      if (!_handlingRecursiveErrorSending)
+      {
+        EventHandler<RaygunSendingMessageEventArgs> handler = SendingMessage;
+
+        if (handler != null)
+        {
+          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage);
+
+          try
+          {
+            handler(this, args);
+          }
+          catch (Exception e)
+          {
+            // Catch and send exceptions that occur in the SendingMessage event handler.
+            // Set the _handlingRecursiveErrorSending flag to prevent infinite errors.
+            _handlingRecursiveErrorSending = true;
+            Send(e);
+            _handlingRecursiveErrorSending = false;
+          }
+
+          result = !args.Cancel;
+        }
+      }
+
+      return result;
+    }
+
+    /// <summary>
+    /// Raised before a message is sent. This can be used to add a custom grouping key to a RaygunMessage before sending it to the Raygun service.
+    /// </summary>
+    public event EventHandler<RaygunCustomGroupingKeyEventArgs> CustomGroupingKey;
+
+    private bool _handlingRecursiveGrouping;
+    protected string OnCustomGroupingKey(Exception exception, RaygunMessage message)
+    {
+      string result = null;
+      if(!_handlingRecursiveGrouping)
+      {
+        var handler = CustomGroupingKey;
+        if(handler != null)
+        {
+          var args = new RaygunCustomGroupingKeyEventArgs(exception, message);
+          try
+          {
+            handler(this, args);
+          }
+          catch (Exception e)
+          {
+            _handlingRecursiveGrouping = true;
+            Send(e);
+            _handlingRecursiveGrouping = false;
+          }
+          result = args.CustomGroupingKey;
+        }
+      }
+      return result;
+    }
+
+    /// <summary>
+    /// Transmits an exception to Raygun.io synchronously.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    public abstract void Send(Exception exception);
+
+    /// <summary>
+    /// Posts a RaygunMessage to the Raygun.io api endpoint.
+    /// </summary>
+    /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
+    /// set to a valid DateTime and as much of the Details property as is available.</param>
+    /// <param name="exception">The original exception used to generate the RaygunMessage</param>
+    public abstract void Send(RaygunMessage raygunMessage);
+  }
+}

--- a/Mindscape.Raygun4Net.Xamarin.Mac/RaygunSendingMessageEventArgs.cs
+++ b/Mindscape.Raygun4Net.Xamarin.Mac/RaygunSendingMessageEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.ComponentModel;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net
+{
+  /// <summary>
+  /// Can be used to modify the message before sending, or to cancel the send operation.
+  /// </summary>
+  public class RaygunSendingMessageEventArgs : CancelEventArgs
+  {
+    private RaygunMessage _raygunMessage;
+    
+    public RaygunSendingMessageEventArgs(RaygunMessage message)
+    {
+      _raygunMessage = message;
+    }
+
+    public RaygunMessage Message
+    {
+      get { return _raygunMessage; }
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Mindscape.Raygun4Net.Xamarin.iOS.Unified.csproj
+++ b/Mindscape.Raygun4Net.Xamarin.iOS.Unified/Mindscape.Raygun4Net.Xamarin.iOS.Unified.csproj
@@ -125,12 +125,6 @@
     <Compile Include="..\Mindscape.Raygun4Net\IRaygunMessageBuilder.cs">
       <Link>IRaygunMessageBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunClientBase.cs">
-      <Link>RaygunClientBase.cs</Link>
-    </Compile>
-    <Compile Include="..\Mindscape.Raygun4Net\RaygunSendingMessageEventArgs.cs">
-      <Link>RaygunSendingMessageEventArgs.cs</Link>
-    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Mindscape.Raygun4Net\Messages\RaygunClientMessage.cs">
       <Link>Messages\RaygunClientMessage.cs</Link>
@@ -158,6 +152,9 @@
     </Compile>
     <Compile Include="..\Mindscape.Raygun4Net.WindowsStore\Messages\RaygunMessageDetails.cs">
       <Link>Messages\RaygunMessageDetails.cs</Link>
+    </Compile>
+    <Compile Include="..\Mindscape.Raygun4Net.Xamarin.iOS\RaygunClientBase.cs">
+      <Link>RaygunClientBase.cs</Link>
     </Compile>
     <Compile Include="..\Mindscape.Raygun4Net.Xamarin.iOS\RaygunClient.cs">
       <Link>RaygunClient.cs</Link>
@@ -204,6 +201,9 @@
     <Compile Include="RaygunLogLevel.cs" />
     <Compile Include="RaygunFile.cs" />
     <Compile Include="RaygunFileManager.cs" />
+    <Compile Include="..\Mindscape.Raygun4Net.Xamarin.iOS\RaygunSendingMessageEventArgs.cs">
+      <Link>RaygunSendingMessageEventArgs.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <NativeReference Include="native\raygun4apple.framework">

--- a/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS/RaygunClientBase.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Net;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net
+{
+  public abstract class RaygunClientBase
+  {
+    protected internal const string SentKey = "AlreadySentByRaygun";
+
+    /// <summary>
+    /// Gets or sets the user identity string.
+    /// </summary>
+    public virtual string User { get; set; }
+
+    /// <summary>
+    /// Gets or sets information about the user including the identity string.
+    /// </summary>
+    public virtual RaygunIdentifierMessage UserInfo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the context identifier defining a scope under which errors are related
+    /// </summary>
+    public string ContextId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a custom application version identifier for all error messages sent to the Raygun endpoint.
+    /// </summary>
+    public string ApplicationVersion { get; set; }
+
+    protected virtual bool CanSend(Exception exception)
+    {
+      return exception == null || exception.Data == null || !exception.Data.Contains(SentKey) || false.Equals(exception.Data[SentKey]);
+    }
+
+    protected void FlagAsSent(Exception exception)
+    {
+      if (exception != null && exception.Data != null)
+      {
+        try
+        {
+          Type[] genericTypes = exception.Data.GetType().GetGenericArguments();
+          if (genericTypes.Length == 0 || genericTypes[0].IsAssignableFrom(typeof(string)))
+          {
+            exception.Data[SentKey] = true;
+          }
+        }
+        catch (Exception ex)
+        {
+          System.Diagnostics.Debug.WriteLine(String.Format("Failed to flag exception as sent: {0}", ex.Message));
+        }
+      }
+    }
+
+    /// <summary>
+    /// Raised just before a message is sent. This can be used to make final adjustments to the <see cref="RaygunMessage"/>, or to cancel the send.
+    /// </summary>
+    public event EventHandler<RaygunSendingMessageEventArgs> SendingMessage;
+
+    private bool _handlingRecursiveErrorSending;
+
+    // Returns true if the message can be sent, false if the sending is canceled.
+    protected bool OnSendingMessage(RaygunMessage raygunMessage)
+    {
+      bool result = true;
+
+      if (!_handlingRecursiveErrorSending)
+      {
+        EventHandler<RaygunSendingMessageEventArgs> handler = SendingMessage;
+
+        if (handler != null)
+        {
+          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage);
+
+          try
+          {
+            handler(this, args);
+          }
+          catch (Exception e)
+          {
+            // Catch and send exceptions that occur in the SendingMessage event handler.
+            // Set the _handlingRecursiveErrorSending flag to prevent infinite errors.
+            _handlingRecursiveErrorSending = true;
+            Send(e);
+            _handlingRecursiveErrorSending = false;
+          }
+
+          result = !args.Cancel;
+        }
+      }
+
+      return result;
+    }
+
+    /// <summary>
+    /// Raised before a message is sent. This can be used to add a custom grouping key to a RaygunMessage before sending it to the Raygun service.
+    /// </summary>
+    public event EventHandler<RaygunCustomGroupingKeyEventArgs> CustomGroupingKey;
+
+    private bool _handlingRecursiveGrouping;
+    protected string OnCustomGroupingKey(Exception exception, RaygunMessage message)
+    {
+      string result = null;
+      if(!_handlingRecursiveGrouping)
+      {
+        var handler = CustomGroupingKey;
+        if(handler != null)
+        {
+          var args = new RaygunCustomGroupingKeyEventArgs(exception, message);
+          try
+          {
+            handler(this, args);
+          }
+          catch (Exception e)
+          {
+            _handlingRecursiveGrouping = true;
+            Send(e);
+            _handlingRecursiveGrouping = false;
+          }
+          result = args.CustomGroupingKey;
+        }
+      }
+      return result;
+    }
+
+    /// <summary>
+    /// Transmits an exception to Raygun.io synchronously.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    public abstract void Send(Exception exception);
+
+    /// <summary>
+    /// Posts a RaygunMessage to the Raygun.io api endpoint.
+    /// </summary>
+    /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
+    /// set to a valid DateTime and as much of the Details property as is available.</param>
+    /// <param name="exception">The original exception used to generate the RaygunMessage</param>
+    public abstract void Send(RaygunMessage raygunMessage);
+  }
+}

--- a/Mindscape.Raygun4Net.Xamarin.iOS/RaygunSendingMessageEventArgs.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS/RaygunSendingMessageEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.ComponentModel;
+using Mindscape.Raygun4Net.Messages;
+
+namespace Mindscape.Raygun4Net
+{
+  /// <summary>
+  /// Can be used to modify the message before sending, or to cancel the send operation.
+  /// </summary>
+  public class RaygunSendingMessageEventArgs : CancelEventArgs
+  {
+    private RaygunMessage _raygunMessage;
+    
+    public RaygunSendingMessageEventArgs(RaygunMessage message)
+    {
+      _raygunMessage = message;
+    }
+
+    public RaygunMessage Message
+    {
+      get { return _raygunMessage; }
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.nuspec
+++ b/Mindscape.Raygun4Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net</id>
-    <version>5.10.2</version>
+    <version>5.11.0</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -251,7 +251,7 @@ namespace Mindscape.Raygun4Net
       {
         _currentRequestMessage = BuildRequestMessage();
 
-        Send(BuildMessage(exception, tags, userCustomData, userInfo, null));
+        Send(BuildMessage(exception, tags, userCustomData, userInfo, null), exception);
         FlagAsSent(exception);
       }
     }
@@ -307,7 +307,7 @@ namespace Mindscape.Raygun4Net
           try
           {
             _currentRequestMessage = currentRequestMessage;
-            Send(BuildMessage(exception, tags, userCustomData, userInfo, currentTime));
+            Send(BuildMessage(exception, tags, userCustomData, userInfo, currentTime), exception);
           }
           catch (Exception)
           {
@@ -328,9 +328,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void SendInBackground(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception that generated the RaygunMessage</param>
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
     {
-      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage));
+      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }
 
     private RaygunRequestMessage BuildRequestMessage()
@@ -409,9 +410,9 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public override void Send(RaygunMessage raygunMessage)
+    public override void Send(RaygunMessage raygunMessage, Exception exception)
     {
-      bool canSend = OnSendingMessage(raygunMessage);
+      bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)
       {
         string message = null;

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -301,7 +301,7 @@ namespace Mindscape.Raygun4Net
         // otherwise it will be disposed while we are using it on the other thread.
         RaygunRequestMessage currentRequestMessage = BuildRequestMessage();
         DateTime currentTime = DateTime.UtcNow;
-        
+
         ThreadPool.QueueUserWorkItem(c =>
         {
           try
@@ -410,7 +410,8 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public override void Send(RaygunMessage raygunMessage, Exception exception)
+    /// <param name="exception">The original exception that generated the RaygunMessage</param>
+    public override void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)

--- a/Mindscape.Raygun4Net/RaygunClient.cs
+++ b/Mindscape.Raygun4Net/RaygunClient.cs
@@ -328,8 +328,8 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    /// <param name="exception">The original exception that generated the RaygunMessage</param>
-    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
+    /// <param name="exception">The original exception object that the <paramref name="raygunMessage"/> is based upon.</param>
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception = null)
     {
       ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }

--- a/Mindscape.Raygun4Net/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net/RaygunClientBase.cs
@@ -132,6 +132,6 @@ namespace Mindscape.Raygun4Net
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception used to generate the RaygunMessage</param>
-    public abstract void Send(RaygunMessage raygunMessage, Exception exception);
+    public abstract void Send(RaygunMessage raygunMessage, Exception exception = null);
   }
 }

--- a/Mindscape.Raygun4Net/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net/RaygunClientBase.cs
@@ -60,7 +60,7 @@ namespace Mindscape.Raygun4Net
     private bool _handlingRecursiveErrorSending;
 
     // Returns true if the message can be sent, false if the sending is canceled.
-    protected bool OnSendingMessage(RaygunMessage raygunMessage)
+    protected bool OnSendingMessage(RaygunMessage raygunMessage, Exception exception)
     {
       bool result = true;
 
@@ -69,7 +69,7 @@ namespace Mindscape.Raygun4Net
         EventHandler<RaygunSendingMessageEventArgs> handler = SendingMessage;
         if (handler != null)
         {
-          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage);
+          RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage, exception);
           try
           {
             handler(this, args);
@@ -131,6 +131,7 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public abstract void Send(RaygunMessage raygunMessage);
+    /// <param name="exception">The original exception used to generate the RaygunMessage</param>
+    public abstract void Send(RaygunMessage raygunMessage, Exception exception);
   }
 }

--- a/Mindscape.Raygun4Net/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net/RaygunClientBase.cs
@@ -67,9 +67,11 @@ namespace Mindscape.Raygun4Net
       if (!_handlingRecursiveErrorSending)
       {
         EventHandler<RaygunSendingMessageEventArgs> handler = SendingMessage;
+
         if (handler != null)
         {
           RaygunSendingMessageEventArgs args = new RaygunSendingMessageEventArgs(raygunMessage, exception);
+
           try
           {
             handler(this, args);
@@ -82,6 +84,7 @@ namespace Mindscape.Raygun4Net
             Send(e);
             _handlingRecursiveErrorSending = false;
           }
+
           result = !args.Cancel;
         }
       }

--- a/Mindscape.Raygun4Net/RaygunSendingMessageEventArgs.cs
+++ b/Mindscape.Raygun4Net/RaygunSendingMessageEventArgs.cs
@@ -9,11 +9,13 @@ namespace Mindscape.Raygun4Net
   /// </summary>
   public class RaygunSendingMessageEventArgs : CancelEventArgs
   {
-    public RaygunSendingMessageEventArgs(RaygunMessage message)
+    public RaygunSendingMessageEventArgs(RaygunMessage message, Exception exception)
     {
       Message = message;
+      Exception = exception;
     }
 
-    public RaygunMessage Message { get; private set; }
+    public RaygunMessage Message { get; }
+    public Exception Exception { get; }
   }
 }

--- a/Mindscape.Raygun4Net/RaygunSendingMessageEventArgs.cs
+++ b/Mindscape.Raygun4Net/RaygunSendingMessageEventArgs.cs
@@ -9,13 +9,23 @@ namespace Mindscape.Raygun4Net
   /// </summary>
   public class RaygunSendingMessageEventArgs : CancelEventArgs
   {
+    private RaygunMessage _raygunMessage;
+    private Exception _exception;
+    
     public RaygunSendingMessageEventArgs(RaygunMessage message, Exception exception)
     {
-      Message = message;
-      Exception = exception;
+      _raygunMessage = message;
+      _exception = exception;
     }
 
-    public RaygunMessage Message { get; }
-    public Exception Exception { get; }
+    public RaygunMessage Message
+    {
+      get { return _raygunMessage; }
+    }
+    
+    public Exception Exception
+    {
+      get { return _exception; }
+    }
   }
 }

--- a/Mindscape.Raygun4Net/RaygunSendingMessageEventArgs.cs
+++ b/Mindscape.Raygun4Net/RaygunSendingMessageEventArgs.cs
@@ -11,6 +11,11 @@ namespace Mindscape.Raygun4Net
   {
     private RaygunMessage _raygunMessage;
     private Exception _exception;
+
+    public RaygunSendingMessageEventArgs(RaygunMessage message)
+    : this(message, null)
+    {
+    }
     
     public RaygunSendingMessageEventArgs(RaygunMessage message, Exception exception)
     {

--- a/Mindscape.Raygun4Net2.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net2.Tests/Model/FakeRaygunClient.cs
@@ -25,9 +25,9 @@ namespace Mindscape.Raygun4Net2.Tests
       return ValidateApiKey();
     }
 
-    public bool ExposeOnSendingMessage(RaygunMessage message)
+    public bool ExposeOnSendingMessage(RaygunMessage message, Exception exception)
     {
-      return OnSendingMessage(message);
+      return OnSendingMessage(message, exception);
     }
   }
 }

--- a/Mindscape.Raygun4Net2.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net2.Tests/RaygunClientTests.cs
@@ -258,7 +258,7 @@ namespace Mindscape.Raygun4Net2.Tests
     [Test]
     public void NoHandlerSendsAll()
     {
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -271,7 +271,7 @@ namespace Mindscape.Raygun4Net2.Tests
         filterCalled = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filterCalled);
     }
 
@@ -282,7 +282,7 @@ namespace Mindscape.Raygun4Net2.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -302,7 +302,7 @@ namespace Mindscape.Raygun4Net2.Tests
         filter2Called = true;
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
       Assert.IsTrue(filter1Called);
       Assert.IsTrue(filter2Called);
     }
@@ -318,7 +318,7 @@ namespace Mindscape.Raygun4Net2.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -332,7 +332,7 @@ namespace Mindscape.Raygun4Net2.Tests
       {
         e.Cancel = true;
       };
-      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsFalse(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -346,7 +346,7 @@ namespace Mindscape.Raygun4Net2.Tests
       {
         // Allow send by not setting e.Cancel
       };
-      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception)));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(_client.ExposeBuildMessage(_exception), _exception));
     }
 
     [Test]
@@ -360,7 +360,7 @@ namespace Mindscape.Raygun4Net2.Tests
         e.Message.Details.Error.Message = "Custom error message";
       };
 
-      Assert.IsTrue(_client.ExposeOnSendingMessage(message));
+      Assert.IsTrue(_client.ExposeOnSendingMessage(message, _exception));
       Assert.AreEqual("Custom error message", message.Details.Error.Message);
     }
   }

--- a/Mindscape.Raygun4Net2/RaygunClient.cs
+++ b/Mindscape.Raygun4Net2/RaygunClient.cs
@@ -248,7 +248,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception that gernerated the RaygunMessage</param>
-    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception = null)
     {
       ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }

--- a/Mindscape.Raygun4Net2/RaygunClient.cs
+++ b/Mindscape.Raygun4Net2/RaygunClient.cs
@@ -322,7 +322,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     ///<param name="exception">The original exception that generated the RaygunMessage</param>
-    public override void Send(RaygunMessage raygunMessage, Exception exception)
+    public override void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       if (ValidateApiKey())
       {

--- a/Mindscape.Raygun4Net2/RaygunClient.cs
+++ b/Mindscape.Raygun4Net2/RaygunClient.cs
@@ -201,7 +201,7 @@ namespace Mindscape.Raygun4Net
     {
       _currentRequestMessage = BuildRequestMessage();
 
-      Send(BuildMessage(exception, tags, userCustomData, null));
+      Send(BuildMessage(exception, tags, userCustomData, null), exception);
     }
 
     /// <summary>
@@ -238,7 +238,7 @@ namespace Mindscape.Raygun4Net
       DateTime? currentTime = DateTime.UtcNow;
       ThreadPool.QueueUserWorkItem(c => {
         _currentRequestMessage = currentRequestMessage;
-        Send(BuildMessage(exception, tags, userCustomData, currentTime));
+        Send(BuildMessage(exception, tags, userCustomData, currentTime), exception);
       });
     }
 
@@ -247,9 +247,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void SendInBackground(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception that gernerated the RaygunMessage</param>
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
     {
-      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage));
+      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }
 
     private RaygunRequestMessage BuildRequestMessage()
@@ -320,11 +321,12 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public override void Send(RaygunMessage raygunMessage)
+    ///<param name="exception">The original exception that generated the RaygunMessage</param>
+    public override void Send(RaygunMessage raygunMessage, Exception exception)
     {
       if (ValidateApiKey())
       {
-        bool canSend = OnSendingMessage(raygunMessage);
+        bool canSend = OnSendingMessage(raygunMessage, exception);
         if (canSend)
         {
           string message = null;

--- a/Mindscape.Raygun4Net4.ClientProfile/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4.ClientProfile/RaygunClient.cs
@@ -287,7 +287,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception that generated the RaygunMessage</param>
-    public override void Send(RaygunMessage raygunMessage, Exception exception)
+    public override void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)

--- a/Mindscape.Raygun4Net4.ClientProfile/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4.ClientProfile/RaygunClient.cs
@@ -212,9 +212,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void SendInBackground(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception that generated the RaygunMessage</param>
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
     {
-      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage));
+      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }
 
     protected RaygunMessage BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData)
@@ -247,7 +248,7 @@ namespace Mindscape.Raygun4Net
     {
       foreach (Exception e in StripWrapperExceptions(exception))
       {
-        Send(BuildMessage(e, tags, userCustomData, userInfo, currentTime));
+        Send(BuildMessage(e, tags, userCustomData, userInfo, currentTime), exception);
       }
     }
 
@@ -285,9 +286,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public override void Send(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception that generated the RaygunMessage</param>
+    public override void Send(RaygunMessage raygunMessage, Exception exception)
     {
-      bool canSend = OnSendingMessage(raygunMessage);
+      bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)
       {
         string message = null;

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -259,7 +259,7 @@ namespace Mindscape.Raygun4Net
 
     /// <summary>
     /// Add an <see cref="IRaygunDataFilter"/> implementation to be used when capturing the raw data
-    /// of a HTTP request. This filter will be passed the request raw data and is expected to remove 
+    /// of a HTTP request. This filter will be passed the request raw data and is expected to remove
     /// or replace values whose keys are found in the list supplied to the Filter method.
     /// </summary>
     /// <param name="filter">Custom raw data filter implementation.</param>
@@ -450,9 +450,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public void SendInBackground(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception that generated the RaygunMessage</param>
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
     {
-      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage));
+      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }
 
     private RaygunRequestMessage BuildRequestMessage()
@@ -522,7 +523,7 @@ namespace Mindscape.Raygun4Net
     {
       foreach (Exception e in StripWrapperExceptions(exception))
       {
-        Send(BuildMessage(e, tags, userCustomData, userInfo, currentTime));
+        Send(BuildMessage(e, tags, userCustomData, userInfo, currentTime), exception);
       }
     }
 
@@ -585,9 +586,10 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
-    public override void Send(RaygunMessage raygunMessage)
+    /// <param name="exception">The original exception used to generate the RaygunMessage</param>
+    public override void Send(RaygunMessage raygunMessage, Exception exception)
     {
-      bool canSend = OnSendingMessage(raygunMessage);
+      bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)
       {
         string message = null;
@@ -613,7 +615,7 @@ namespace Mindscape.Raygun4Net
             {
               WebClientHelper.WebProxy = WebProxy;
             }
-              
+
             WebClientHelper.Send(message, _apiKey, ProxyCredentials);
           }
           catch (Exception sendMessageException)
@@ -621,7 +623,7 @@ namespace Mindscape.Raygun4Net
             try
             {
               System.Diagnostics.Trace.WriteLine($"Error sending exception to Raygun.io due to: {sendMessageException}");
-              
+
               // Attempt to store the message in isolated storage.
               SaveMessage(message);
             }
@@ -714,7 +716,7 @@ namespace Mindscape.Raygun4Net
           System.Diagnostics.Debug.WriteLine("ApiKey has not been provided, skipping sending stored Raygun messages");
           return;
         }
-        
+
         try
         {
           using (IsolatedStorageFile isolatedStorage = GetIsolatedStorageScope())
@@ -735,7 +737,7 @@ namespace Mindscape.Raygun4Net
                     {
                       WebClientHelper.WebProxy = WebProxy;
                     }
-                    
+
                     WebClientHelper.Send(text, _apiKey, ProxyCredentials);
                   }
                   catch

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -451,7 +451,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception that generated the RaygunMessage</param>
-    public void SendInBackground(RaygunMessage raygunMessage, Exception exception)
+    public void SendInBackground(RaygunMessage raygunMessage, Exception exception = null)
     {
       ThreadPool.QueueUserWorkItem(c => Send(raygunMessage, exception));
     }
@@ -589,8 +589,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="exception">The original exception used to generate the RaygunMessage</param>
     public override void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
-      bool canSend = OnSendingMessage(raygunMessage, exception);
-      if (canSend)
+      if (OnSendingMessage(raygunMessage, exception))
       {
         string message = null;
         try

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -587,7 +587,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
     /// set to a valid DateTime and as much of the Details property as is available.</param>
     /// <param name="exception">The original exception used to generate the RaygunMessage</param>
-    public override void Send(RaygunMessage raygunMessage, Exception exception)
+    public override void Send(RaygunMessage raygunMessage, Exception exception = null)
     {
       bool canSend = OnSendingMessage(raygunMessage, exception);
       if (canSend)


### PR DESCRIPTION
Update the `SendingMessage` event to include the original exception alongside the `RaygunMessage` object. This allows customers to perform further operations on the exception to extract contextual information only available on the exception.

Ticket: https://raygun.atlassian.net/browse/CR-204