### PR TITLE
Make the Raygun directory configurable for Xamarin.iOS

### DIFF
--- a/Mindscape.Raygun4Net.Xamarin.iOS.Unified/RaygunFileManager.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS.Unified/RaygunFileManager.cs
@@ -9,7 +9,6 @@ namespace Mindscape.Raygun4Net
   public class RaygunFileManager
   {
     public const int MAX_STORED_REPORTS_UPPER_LIMIT = 64;
-    private const string RAYGUN_DIRECTORY = "RaygunIO";
 
     private int currentFileCounter = 0;
 
@@ -174,7 +173,7 @@ namespace Mindscape.Raygun4Net
 
     private string GetCrashReportDirectory()
     {
-      return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), RAYGUN_DIRECTORY);
+      return RaygunSettings.Settings.RaygunDirectory;
     }
 
     private string GetUniqueAcendingJsonName()

--- a/Mindscape.Raygun4Net.Xamarin.iOS/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.Xamarin.iOS/RaygunSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace Mindscape.Raygun4Net
 {
@@ -7,6 +8,7 @@ namespace Mindscape.Raygun4Net
     private static RaygunSettings settings;
     private const string DefaultApiEndPoint = "https://api.raygun.io/entries";
     private const string DefaultPulseEndPoint = "https://api.raygun.io/events";
+    private const string DefaultRaygunDirectory = "RaygunIO";
 
     public static RaygunSettings Settings
     {
@@ -15,7 +17,8 @@ namespace Mindscape.Raygun4Net
         return settings ?? (settings = new RaygunSettings {
           ApiEndpoint = new Uri(DefaultApiEndPoint), 
           PulseEndpoint = new Uri(DefaultPulseEndPoint), 
-          LogLevel = RaygunLogLevel.Warning
+          LogLevel = RaygunLogLevel.Warning,
+          RaygunDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), DefaultRaygunDirectory)
         });
       }
     }
@@ -27,5 +30,7 @@ namespace Mindscape.Raygun4Net
     public bool SetUnobservedTaskExceptionsAsObserved { get; set; }
 
     public RaygunLogLevel LogLevel { get; set; }
+
+    public string RaygunDirectory { get; set; }
   }
 }


### PR DESCRIPTION
Per the [discussion](https://raygun.com/forums/thread/163861) on the RayGun Forums, I have added support for configuring the path of the directory used to store crash report data into RaygunSettings.

This is necessary because if you are writing a document based Xamarin.iOS app, the "RaygunIO" folder will be visible with the local documents directory of your app (and any other document browser based app such as Files).