### PR TITLE
#421 No need to clear the current HttpContext when populating

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
@@ -250,16 +250,12 @@ namespace Mindscape.Raygun4Net.AspNetCore
 
     private async Task<RaygunRequestMessage> BuildRequestMessage()
     {
-      var message = _currentHttpContext.Value != null ? await RaygunAspNetCoreRequestMessageBuilder.Build(_currentHttpContext.Value, _requestMessageOptions) : null;
-      _currentHttpContext.Value = null;
-      return message;
+      return _currentHttpContext.Value != null ? await RaygunAspNetCoreRequestMessageBuilder.Build(_currentHttpContext.Value, _requestMessageOptions) : null;
     }
 
     private RaygunResponseMessage BuildResponseMessage()
     {
-      var message = _currentHttpContext.Value != null ? RaygunAspNetCoreResponseMessageBuilder.Build(_currentHttpContext.Value) : null;
-      _currentHttpContext.Value = null;
-      return message;
+      return _currentHttpContext.Value != null ? RaygunAspNetCoreResponseMessageBuilder.Build(_currentHttpContext.Value) : null;
     }
 
     public RaygunClient SetCurrentContext(HttpContext request)

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -632,9 +632,7 @@ namespace Mindscape.Raygun4Net.WebApi
 
     private RaygunRequestMessage BuildRequestMessage()
     {
-      var message = _currentWebRequest.Value != null ? RaygunWebApiRequestMessageBuilder.Build(_currentWebRequest.Value, _requestMessageOptions) : null;
-      _currentWebRequest.Value = null;
-      return message;
+      return _currentWebRequest.Value != null ? RaygunWebApiRequestMessageBuilder.Build(_currentWebRequest.Value, _requestMessageOptions) : null;
     }
 
     protected RaygunMessage BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData)


### PR DESCRIPTION
This caused a subtle bug where the first exception reported would include the request context, but subsequent exceptions would not.

In addition, the AspNetCore version would never set the StatusCode or StatusDescription in the Response
since _currentHttpContext was set to null by BuildRequestMessage() just before BuildResponseMessage() was called.
Note that StatusCode would not typically be set if an exception occurred on ASP.NET Core since the Raygun HTTP
module does not exist on this platform, but custom middleware might want to do this.
For example, custom middleware might watch for certain HTTP status codes and report them.

As long as RaygunClient objects are short-lived, this should not cause any memory leaks.