### PR TITLE
Use async local

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
@@ -14,9 +14,9 @@ namespace Mindscape.Raygun4Net.AspNetCore
   {
     protected readonly RaygunRequestMessageOptions _requestMessageOptions = new RaygunRequestMessageOptions();
 
-    private readonly ThreadLocal<HttpContext> _currentHttpContext = new ThreadLocal<HttpContext>(() => null);
-    private readonly ThreadLocal<RaygunRequestMessage> _currentRequestMessage = new ThreadLocal<RaygunRequestMessage>(() => null);
-    private readonly ThreadLocal<RaygunResponseMessage> _currentResponseMessage = new ThreadLocal<RaygunResponseMessage>(() => null);
+    private readonly AsyncLocal<HttpContext> _currentHttpContext = new AsyncLocal<HttpContext>();
+    private readonly AsyncLocal<RaygunRequestMessage> _currentRequestMessage = new AsyncLocal<RaygunRequestMessage>();
+    private readonly AsyncLocal<RaygunResponseMessage> _currentResponseMessage = new AsyncLocal<RaygunResponseMessage>();
 
     public RaygunClient(string apiKey)
       : this(new RaygunSettings {ApiKey = apiKey})

--- a/Mindscape.Raygun4Net/ProfilingSupport/APM.cs
+++ b/Mindscape.Raygun4Net/ProfilingSupport/APM.cs
@@ -9,7 +9,7 @@ namespace Mindscape.Raygun4Net
 {
   public static class APM
   {
-    [ThreadStatic] private static bool _enabled = false;
+    [ThreadStatic] private static bool _enabled;
 
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     public static void Enable()


### PR DESCRIPTION
Here are a few cleanups related to #371.

The ASP.NET Core version was updated from ThreadLocal to AsyncLocal, since it uses async-based code:
https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1?view=netcore-3.1#examples

Additionally, I removed an initializer for a ThreadStatic variable, since initializers are only applied to the first thread that accesses the ThreadStatic.  The variable for each subsequent thread uses the default initializer.  Another option would be to replace ThreadStatic with ThreadLocal, which allows you to provide an initializer, but that wasn't necessary in this case.
https://docs.microsoft.com/en-us/dotnet/api/system.threadstaticattribute?view=netcore-3.1#remarks