### PR TITLE
Add an override for the SendAsync method in the ASP.NET CORE RaygunClient

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/README.md
+++ b/Mindscape.Raygun4Net.AspNetCore/README.md
@@ -127,35 +127,19 @@ public class RaygunController : Controller
 
 ### Using a singleton RaygunClient
 
-If you are using a singleton RaygunClient, or have implemented an `IRaygunAspNetCoreClientProvider` which returns a singleton RaygunClient, you'll need to manually set the HTTP context before manually sending an exception.
+If you are using a singleton RaygunClient, you'll need to manually set the HTTP context (if applicable) before manually sending an exception.
 
-#### Using custom RaygunClient
+#### Example using a custom RaygunClient
 
 ```csharp
 try
 {
   data = JsonSerializer.Deserialize<SomeModel>(suspiciousString);
 }
-catch (Exception ex)
+catch (JsonException ex)
 {
   _singletonRaygunClient.SetCurrentContext(HttpContext);
   await _singletonRaygunClient.Send(ex);
-}
-```
-
-#### Using custom provider
-
-```csharp
-try
-{
-  data = JsonSerializer.Deserialize<SomeModel>(suspiciousString);
-}
-catch (Exception ex)
-{
-  // Custom provider returns RaygunClient singleton
-  var raygunClient = _clientProvider.GetClient(_settings.Value);
-  raygunClient.SetCurrentContext(HttpContext);
-  await raygunClient.Send(ex);
 }
 ```
 

--- a/Mindscape.Raygun4Net.AspNetCore/README.md
+++ b/Mindscape.Raygun4Net.AspNetCore/README.md
@@ -125,6 +125,40 @@ public class RaygunController : Controller
 }
 ```
 
+### Using a singleton RaygunClient
+
+If you are using a singleton RaygunClient, or have implemented an `IRaygunAspNetCoreClientProvider` which returns a singleton RaygunClient, you'll need to manually set the HTTP context before manually sending an exception.
+
+#### Using custom RaygunClient
+
+```csharp
+try
+{
+  data = JsonSerializer.Deserialize<SomeModel>(suspiciousString);
+}
+catch (Exception ex)
+{
+  _singletonRaygunClient.SetCurrentContext(HttpContext);
+  await _singletonRaygunClient.Send(ex);
+}
+```
+
+#### Using custom provider
+
+```csharp
+try
+{
+  data = JsonSerializer.Deserialize<SomeModel>(suspiciousString);
+}
+catch (Exception ex)
+{
+  // Custom provider returns RaygunClient singleton
+  var raygunClient = _clientProvider.GetClient(_settings.Value);
+  raygunClient.SetCurrentContext(HttpContext);
+  await raygunClient.Send(ex);
+}
+```
+
 Additional configuration options and features
 =============================================
 

--- a/Mindscape.Raygun4Net.AspNetCore/README.md
+++ b/Mindscape.Raygun4Net.AspNetCore/README.md
@@ -129,17 +129,30 @@ public class RaygunController : Controller
 
 If you are using a singleton RaygunClient, you'll need to manually set the HTTP context (if applicable) before manually sending an exception.
 
-#### Example using a custom RaygunClient
-
 ```csharp
-try
+public class RaygunController : Controller
 {
-  data = JsonSerializer.Deserialize<SomeModel>(suspiciousString);
-}
-catch (JsonException ex)
-{
-  _singletonRaygunClient.SetCurrentContext(HttpContext);
-  await _singletonRaygunClient.Send(ex);
+  private readonly RaygunClient _singletonRaygunClient;
+
+  public RaygunController(RaygunClient singletonRaygunClient)
+  {
+    _singletonRaygunClient = singletonRaygunClient;
+  }
+
+  public async Task<IActionResult> TestManualError()
+  {
+    try
+    {
+      throw new Exception("Test from .NET Core MVC app");
+    }
+    catch (Exception ex)
+    {
+      _singletonRaygunClient.SetCurrentContext(HttpContext);
+      await _singletonRaygunClient.Send(ex);
+    }
+
+    return View();
+  }
 }
 ```
 

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunClient.cs
@@ -227,6 +227,9 @@ namespace Mindscape.Raygun4Net.AspNetCore
       {
         RaygunRequestMessage currentRequestMessage = await BuildRequestMessage();
         RaygunResponseMessage currentResponseMessage = BuildResponseMessage();
+
+        _currentHttpContext.Value = null;
+
         _currentRequestMessage.Value = currentRequestMessage;
         _currentResponseMessage.Value = currentResponseMessage;
 
@@ -251,10 +254,13 @@ namespace Mindscape.Raygun4Net.AspNetCore
         RaygunRequestMessage currentRequestMessage = await BuildRequestMessage();
         RaygunResponseMessage currentResponseMessage = BuildResponseMessage();
 
+        _currentHttpContext.Value = null;
+
         var task = Task.Run(async () =>
         {
           _currentRequestMessage.Value = currentRequestMessage;
           _currentResponseMessage.Value = currentResponseMessage;
+
           await StripAndSend(exception, tags, userCustomData, userInfo);
         });
         FlagAsSent(exception);
@@ -264,16 +270,12 @@ namespace Mindscape.Raygun4Net.AspNetCore
 
     private async Task<RaygunRequestMessage> BuildRequestMessage()
     {
-      var message = _currentHttpContext.Value != null ? await RaygunAspNetCoreRequestMessageBuilder.Build(_currentHttpContext.Value, _requestMessageOptions) : null;
-      _currentHttpContext.Value = null;
-      return message;
+      return _currentHttpContext.Value != null ? await RaygunAspNetCoreRequestMessageBuilder.Build(_currentHttpContext.Value, _requestMessageOptions) : null;
     }
 
     private RaygunResponseMessage BuildResponseMessage()
     {
-      var message = _currentHttpContext.Value != null ? RaygunAspNetCoreResponseMessageBuilder.Build(_currentHttpContext.Value) : null;
-      _currentHttpContext.Value = null;
-      return message;
+      return _currentHttpContext.Value != null ? RaygunAspNetCoreResponseMessageBuilder.Build(_currentHttpContext.Value) : null;
     }
 
     public RaygunClient SetCurrentContext(HttpContext request)


### PR DESCRIPTION
## Overview

When using the `RaygunClient.Send()` overload in an ASP.NET Core MVC application, the HTTP request details are not being included in the message being sent to the API. This change adds an override for the `SendAsync` method which awaits the retrieval of the request details and sets them on the ThreadLocal value which is used in the `BuildMessage` method.

### Updates

- Add override for the SendAsync method in the ASP.NET Core RaygunClient 
- The HTTP context is not set to null until after the request and response messages have been built
- Add docs to the readme for the case where a singleton RaygunClient object is used