### PR TITLE
Update psake

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit.Runners" version="2.6.2" />
-  <package id="psake" version="4.8.0" />
+  <package id="psake" version="4.9.0" />
 </packages>

--- a/Mindscape.Raygun4Net.Mvc/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.Mvc/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.11.0.0")]
-[assembly: AssemblyFileVersion("5.11.0.0")]
+[assembly: AssemblyVersion("5.12.0.0")]
+[assembly: AssemblyFileVersion("5.12.0.0")]

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,4 @@
 .\.nuget\NuGet.exe install .nuget\packages.config -o packages
-.\packages\psake.4.8.0\tools\psake\psake.cmd build.ps1 %*
+.\packages\psake.4.9.0\tools\psake\psake.cmd build.ps1 %*
 
 pause

--- a/buildNetCore.bat
+++ b/buildNetCore.bat
@@ -1,4 +1,4 @@
 .\.nuget\NuGet.exe install .nuget\packages.config -o packages
-.\packages\psake.4.8.0\tools\psake\psake.cmd buildNetCore.ps1 %*
+.\packages\psake.4.9.0\tools\psake\psake.cmd buildNetCore.ps1 %*
 
 pause

--- a/buildSigned.bat
+++ b/buildSigned.bat
@@ -1,4 +1,4 @@
 .\.nuget\NuGet.exe install .nuget\packages.config -o packages
-.\packages\psake.4.8.0\tools\psake\psake.cmd buildSigned.ps1 %*
+.\packages\psake.4.9.0\tools\psake\psake.cmd buildSigned.ps1 %*
 
 pause

--- a/buildWebApi.bat
+++ b/buildWebApi.bat
@@ -1,4 +1,4 @@
 set EnableNuGetPackageRestore=true
-call .\packages\psake.4.3.2\tools\psake.cmd buildWebApi.ps1 %*
+call .\packages\psake.4.9.0\tools\psake\psake.cmd buildWebApi.ps1 %*
 
 pause

--- a/buildWindowsPhone.bat
+++ b/buildWindowsPhone.bat
@@ -1,4 +1,4 @@
 set EnableNuGetPackageRestore=true
-call .\packages\psake.4.3.2\tools\psake.cmd buildWindowsPhone.ps1 %*
+call .\packages\psake.4.9.0\tools\psake\psake.cmd buildWindowsPhone.ps1 %*
 
 pause

--- a/buildWindowsStore.bat
+++ b/buildWindowsStore.bat
@@ -1,4 +1,4 @@
 set EnableNuGetPackageRestore=true
-call .\packages\psake.4.3.2\tools\psake.cmd buildWindowsStore.ps1 %*
+call .\packages\psake.4.9.0\tools\psake\psake.cmd buildWindowsStore.ps1 %*
 
 pause

--- a/buildXamarinAndroid.bat
+++ b/buildXamarinAndroid.bat
@@ -1,4 +1,4 @@
 set EnableNuGetPackageRestore=true
-call .\packages\psake.4.3.2\tools\psake.cmd buildXamarinAndroid.ps1 %*
+call .\packages\psake.4.9.0\tools\psake\psake.cmd buildXamarinAndroid.ps1 %*
 
 pause

--- a/package.bat
+++ b/package.bat
@@ -1,4 +1,4 @@
 set EnableNuGetPackageRestore=true
-call .\packages\psake.4.3.2\tools\psake.cmd package.ps1 %*
+call .\packages\psake.4.9.0\tools\psake\psake.cmd package.ps1 %*
 
 pause

--- a/packageWebApi.bat
+++ b/packageWebApi.bat
@@ -1,4 +1,4 @@
 set EnableNuGetPackageRestore=true
-call .\packages\psake.4.3.2\tools\psake.cmd packageWebApi.ps1 %*
+call .\packages\psake.4.9.0\tools\psake\psake.cmd packageWebApi.ps1 %*
 
 pause


### PR DESCRIPTION
Updated the build scripts to use the latest version of psake. This fixes a path issue with finding msbuild in VS 2019.
Also updated the version number of the Raygun4Net.Mvc project which I'd missed in a previous piece of work.