### PR TITLE
Bump version numbers for release

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -9,7 +9,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting ASP.Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.AspNetCore</PackageId>
-    <PackageVersion>6.5.0</PackageVersion>
+    <PackageVersion>6.6.0</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.5.0")]
-[assembly: AssemblyFileVersion("6.5.0")]
+[assembly: AssemblyVersion("6.6.0")]
+[assembly: AssemblyFileVersion("6.6.0")]


### PR DESCRIPTION
This PR increments the version numbers to prep for the release of this PR that allows Raygun4Net.AspNetCore to be used with .Net 5, #454 

Changes include:
- Bumping version numbers for the AspNetCore project.