### PR TITLE
Bump version numbers for release of PR #455

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -9,7 +9,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting ASP.Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.AspNetCore</PackageId>
-    <PackageVersion>6.6.0</PackageVersion>
+    <PackageVersion>6.6.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -9,7 +9,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting ASP.Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.AspNetCore</PackageId>
-    <PackageVersion>6.6.1</PackageVersion>
+    <PackageVersion>6.6.2</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.6.1")]
-[assembly: AssemblyFileVersion("6.6.1")]
+[assembly: AssemblyVersion("6.6.2")]
+[assembly: AssemblyFileVersion("6.6.2")]

--- a/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.6.0")]
-[assembly: AssemblyFileVersion("6.6.0")]
+[assembly: AssemblyVersion("6.6.1")]
+[assembly: AssemblyFileVersion("6.6.1")]

--- a/Mindscape.Raygun4Net.AspNetCore/README.md
+++ b/Mindscape.Raygun4Net.AspNetCore/README.md
@@ -13,7 +13,7 @@ The main classes can be found in the Mindscape.Raygun4Net namespace.
 Usage
 ======
 
-In your project.json file, add "Mindscape.Raygun4Net.AspNetCore": "6.5.0" to your dependencies.
+In your project.json file, add "Mindscape.Raygun4Net.AspNetCore": "6.6.2" to your dependencies.
 
 Run dotnet.exe restore or restore packages within Visual Studio to download the package.
 

--- a/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunClientMessage.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunClientMessage.cs
@@ -5,7 +5,7 @@
     public RaygunClientMessage()
     {
       Name = "Raygun4Net.NetCore";
-      Version = "6.5.0";
+      Version = "6.5.1";
       ClientUrl = @"https://github.com/MindscapeHQ/raygun4net";
     }
 

--- a/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
+++ b/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
@@ -8,7 +8,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library .NetCore applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore.Common</PackageId>
-    <PackageVersion>6.5.0</PackageVersion>
+    <PackageVersion>6.5.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -13,7 +13,7 @@
     <Authors>Raygun</Authors>
     <Description>.NetStandard library for targeting .Net Core applications</Description>
     <PackageId>Mindscape.Raygun4Net.NetCore</PackageId>
-    <PackageVersion>6.4.0</PackageVersion>
+    <PackageVersion>6.4.1</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/MindscapeHQ/raygun4net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MindscapeHQ/raygun4net</PackageProjectUrl>

--- a/Mindscape.Raygun4Net.NetCore/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.NetCore/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.0")]
-[assembly: AssemblyFileVersion("6.4.0")]
+[assembly: AssemblyVersion("6.4.1")]
+[assembly: AssemblyFileVersion("6.4.1")]

--- a/Mindscape.Raygun4Net.NetCore/README.md
+++ b/Mindscape.Raygun4Net.NetCore/README.md
@@ -13,7 +13,7 @@ The main classes can be found in the Mindscape.Raygun4Net namespace.
 Usage
 =====
 
-In your project file, add "Mindscape.Raygun4Net.NetCore": "6.4.0" to your dependencies.
+In your project file, add "Mindscape.Raygun4Net.NetCore": "6.4.1" to your dependencies.
 
 Run dotnet.exe restore or restore packages within Visual Studio to download the package.
 


### PR DESCRIPTION
This PR increments the version numbers to prep for the release of this PR #455 that adds in ConfigureAwait(false) to the awaited calls in the Mindscape.Raygun4net.NetCore.Common library