### PR TITLE
Fix missing cookie collection in ASP.NET Core provider

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
@@ -76,17 +76,17 @@ namespace Mindscape.Raygun4Net.AspNetCore.Builders
 
     private static IList GetCookies(HttpRequest request, RaygunRequestMessageOptions options)
     {
-      IList cookies = null;
+      IList cookies;
       try
       {
-        if (request.HasFormContentType)
-        {
-          cookies = request.Cookies.Where(c => !options.IsCookieIgnored(c.Key) && !options.IsSensitiveFieldIgnored(c.Key))
-                                   .Select(c => new RaygunRequestMessage.Cookie(c.Key, c.Value)).ToList();
-        }
+	      cookies = request.Cookies.Where(c => !options.IsCookieIgnored(c.Key) && !options.IsSensitiveFieldIgnored(c.Key))
+		      .Select(c => new RaygunRequestMessage.Cookie(c.Key, c.Value)).ToList();
       }
       // ReSharper disable once EmptyGeneralCatchClause
-      catch { }
+      catch (Exception e)
+      {
+	      cookies = new List<string>() { "Failed to retrieve cookies: " + e.Message };
+      }
 
       return cookies;
     }


### PR DESCRIPTION
The check for `request.HasFormContentType` when trying to get cookies from the request should not be there as the Form content has no bearing on a request containing cookies or not. It looks like this was copied over from the original implementation.

I've also added a message to the cookies list if this method fails in line with the other methods in this class.