### PR TITLE
Initialize Tags as List<string> instead of string array in ASP.NET Core middleware

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/RaygunAspNetMiddleware.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunAspNetMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -81,7 +82,7 @@ namespace Mindscape.Raygun4Net.AspNetCore
         }
 
         var client = _middlewareSettings.ClientProvider.GetClient(_settings, httpContext);
-        await client.SendInBackground(e, new []{UnhandledExceptionTag});
+        await client.SendInBackground(e, new List<string>{UnhandledExceptionTag});
         throw;
       }
       finally

--- a/Mindscape.Raygun4Net.AspNetCore2.Tests/ExampleRaygunAspNetCoreClientProvider.cs
+++ b/Mindscape.Raygun4Net.AspNetCore2.Tests/ExampleRaygunAspNetCoreClientProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net.AspNetCore;
+using System.Collections.Generic;
 
 namespace Mindscape.Raygun4Net.AspNetCore2.Tests
 {
@@ -17,7 +18,13 @@ namespace Mindscape.Raygun4Net.AspNetCore2.Tests
                 Email = email,
                 FullName = "Bob"
             };
-            
+
+            client.SendingMessage += (_, args) =>
+            {
+                args.Message.Details.Tags ??= new List<string>();
+                args.Message.Details.Tags.Add("new tag");
+            };
+
             return client;
         }
     }


### PR DESCRIPTION
When the UnhandledException tag is added by the ASP.NET Core middleware, tags are initialized as a string array, which
is of fixed size, preventing additional tags from being added (for example when overriding the Raygun client provider). Initializing as a `List<string>` instead will fix this.

fixes #466