### PR TITLE
Update .NET providers readme

### DIFF
--- a/Mindscape.Raygun4Net.NetCore/README.md
+++ b/Mindscape.Raygun4Net.NetCore/README.md
@@ -10,14 +10,27 @@ Namespace
 =========
 The main classes can be found in the Mindscape.Raygun4Net namespace.
 
-Usage
+Installation
 =====
 
-In your project file, add "Mindscape.Raygun4Net.NetCore": "6.4.3" to your dependencies.
+Install the **Mindscape.Raygun4Net.NetCore** NuGet package into your project. You can either use the below dotnet CLI command, or the NuGet management GUI in the IDE you use.
 
-Run dotnet.exe restore or restore packages within Visual Studio to download the package.
+```
+dotnet add package Mindscape.Raygun4Net.NetCore
+```
 
-Anywhere in your code, you can also send exception reports manually simply by creating a new instance of the RaygunClient and calling one of the Send or SendInBackground methods.
+Create an instance of RaygunClient by passing your app API key to the constructor, and hook it up to the unhandled exception delegate. This is typically done in Program.cs or the main method.
+
+```
+using Mindscape.Raygun4Net;
+
+private static RaygunClient _raygunClient = new RaygunClient("paste_your_api_key_here");
+
+AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledExceptionEventArgs e) =>
+  _raygunClient.Send(e.ExceptionObject as Exception);
+```
+
+Add some temporary code to throw an exception and manually send it to Raygun by calling one of the Send or SendInBackground methods.
 This is most commonly used to send exceptions caught in a try/catch block.
 
 ```

--- a/Mindscape.Raygun4Net.NetCore/README.md
+++ b/Mindscape.Raygun4Net.NetCore/README.md
@@ -3,7 +3,7 @@ Raygun4Net.NetCore - Raygun Provider for .NET Core projects
 
 Where is my app API key?
 ========================
-When you create a new application on your Raygun dashboard, your app API key is displayed at the top of the instructions page.
+When you create a new application on your Raygun dashboard, your app API key is displayed within the instructions page.
 You can also find the API key by clicking the "Application Settings" button in the side bar of the Raygun dashboard.
 
 Namespace
@@ -20,13 +20,16 @@ Run dotnet.exe restore or restore packages within Visual Studio to download the 
 Anywhere in your code, you can also send exception reports manually simply by creating a new instance of the RaygunClient and calling one of the Send or SendInBackground methods.
 This is most commonly used to send exceptions caught in a try/catch block.
 
+```
 try
 {
+  ...
 }
 catch (Exception e)
 {
   new RaygunClient("YOUR_APP_API_KEY").SendInBackground(e);
 } 
+```
 
 Additional configuration options and features
 =============================================
@@ -68,3 +71,6 @@ Tags and custom data
 
 When sending exceptions manually, you can also send an arbitrary list of tags (an array of strings), and a collection of custom data (a dictionary of any objects).
 This can be done using the various Send and SendInBackground method overloads.
+
+---
+See the [Raygun docs](https://raygun.com/documentation/language-guides/dotnet/crash-reporting/net-core/) for a more detailed explanation on how to use this provider.

--- a/Mindscape.Raygun4Net.NetCore/README.md
+++ b/Mindscape.Raygun4Net.NetCore/README.md
@@ -73,4 +73,4 @@ When sending exceptions manually, you can also send an arbitrary list of tags (a
 This can be done using the various Send and SendInBackground method overloads.
 
 ---
-See the [Raygun docs](https://raygun.com/documentation/language-guides/dotnet/crash-reporting/net-core/) for a more detailed explanation on how to use this provider.
+See the [Raygun docs](https://raygun.com/documentation/language-guides/dotnet/crash-reporting/net-core/) for more detailed instructions on how to use this provider.

--- a/Mindscape.Raygun4Net.NetCore/README.md
+++ b/Mindscape.Raygun4Net.NetCore/README.md
@@ -1,4 +1,4 @@
-Raygun4Net.NetCore - Raygun Provider for .NET Core projects
+Raygun4Net.NetCore - Raygun Provider for .NET 6+ projects
 ===========================================================
 
 Where is my app API key?
@@ -30,8 +30,7 @@ AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledException
   _raygunClient.Send(e.ExceptionObject as Exception);
 ```
 
-Add some temporary code to throw an exception and manually send it to Raygun by calling one of the Send or SendInBackground methods.
-This is most commonly used to send exceptions caught in a try/catch block.
+Add some temporary code to throw an exception and manually send it to Raygun.
 
 ```
 try
@@ -40,9 +39,16 @@ try
 }
 catch (Exception e)
 {
-  new RaygunClient("YOUR_APP_API_KEY").SendInBackground(e);
+  _raygunClient.SendInBackground(e);
 } 
 ```
+
+Manually sending exceptions
+------------------------
+
+The above instructions will setup Raygun4Net to automatically detect and send all unhandled exceptions. Sometimes you may want to send exceptions manually, such as handled exceptions from within a try/catch block.
+
+RaygunClient provides Send and SendInBackground methods for manually sending to Raygun. It's important to note that SendInBackground should only be used for handled exceptions, rather than exceptions that will cause the application to crash - otherwise the application will most likely shutdown all threads before Raygun is able to finish sending. 
 
 Additional configuration options and features
 =============================================

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Projects built with the following frameworks are supported:
 
 * .NET 2.0, 3.5, 4.0+
 * .NET 3.5 and 4.0 Client Profile
-* .NET Core 1, 2 (Use the [Mindscape.Raygun4Net.NetCore](https://www.nuget.org/packages/Mindscape.Raygun4Net.NetCore/) package for higher versions)
+* .NET Core 1.0, 2.0, 3.0+
 * ASP.NET
 * Mvc
 * WebApi
@@ -38,6 +38,8 @@ Projects built with the following frameworks are supported:
 Install the NuGet package to a project which uses one of the above frameworks and the correct assembly will be referenced.
 
 For Xamarin we recommended adding either [Raygun4Xamarin.Forms](https://www.nuget.org/packages/Raygun4Xamarin.Forms/), or the [Mindscape.Raygun4Net.Xamarin.Android](https://www.nuget.org/packages/Mindscape.Raygun4Net.Xamarin.Android/) & [Mindscape.Raygun4Net.Xamarin.iOS.Unified](https://www.nuget.org/packages/Mindscape.Raygun4Net.Xamarin.iOS.Unified/) packages.
+
+For .NET Core and .NET versions 5.0 or higher, we recommend using the [Mindscape.Raygun4Net.NetCore](https://www.nuget.org/packages/Mindscape.Raygun4Net.NetCore/) package.
 
 Where is my app API key?
 ====================

--- a/README.md
+++ b/README.md
@@ -2,33 +2,16 @@ Raygun4Net
 ==========
 
 [Raygun](http://raygun.com) provider for .NET Framework
-
-! IMPORTANT CHANGE IN 5.0 !
-====================
-
-If you are manually referencing Raygun4Net dlls in your project rather than installing the NuGet package, then there are some minor dependency changes that you'll need to be aware of:
-
-For Mvc projects, make sure your project references these dlls:
-* Mindscape.Raygun4Net
-* Mindscape.Raygun4Net.Mvc
-* Mindscape Raygun4Net4
-
-For other .Net 4.0+ projects, make sure your project references these dlls:
-* Mindscape.Raygun4Net
-* Mindscape.Raygun4Net4
-
-For both of the above setups, you can find all the correct dlls in the Mvc and Net4 folders respectively within the .zip file hosted on the [latest GitHub release](https://github.com/MindscapeHQ/raygun4net/releases).
-If you build the Raygun4Net projects yourself with the build.bat script, all the correct dlls will be in the raygun4net/build/Mvc and raygun4net/build/Net4 folders.
-Or if you build the Raygun4Net projects in Visual Studio, all the correct dlls will be within the bin folder for each project.
-
-If you are using Raygun4Net in a .Net project type not listed above, or if you are installing via NuGet, then you'll have no problems upgrading to version 5.0. There are no breaking changes in this version.
+This package is up to date with .NET 7
 
 Installation
 ====================
 
-* The easiest way to install this provider is by grabbing the NuGet package. Ensure the NuGet Visual Studio extension is installed, right-click on your project -> Manage NuGet Packages -> Online -> search for **Mindscape.Raygun4Net**, then install the appropriate package. Or, visit https://nuget.org/packages/Mindscape.Raygun4Net/ for instructions on installation using the package manager console.
+* The easiest way to install this provider is by either using the below dotnet CLI command, or in the NuGet management GUI in the IDE you use.
 
-* For Visual Studio 2008 (without NuGet) you can clone this repository, run build.bat, then add project references to **Mindscape.Raygun4Net.dll**
+```
+dotnet add package Mindscape.Raygun4Net
+```
 
 * If you have issues trying to install the package into a WinRT project, see the troubleshooting section below.
 
@@ -39,14 +22,12 @@ Projects built with the following frameworks are supported:
 
 * .NET 2.0, 3.5, 4.0+
 * .NET 3.5 and 4.0 Client Profile
-* .NET Core 1, 2
-* ASP.NET
+* .NET Core 1, 2 (Use the [Mindscape.Raygun4Net.NetCore](https://www.nuget.org/packages/Mindscape.Raygun4Net.NetCore/) package for higher versions)
+* ASP.NET 
 * Mvc
 * WebApi
 * WinForms, WPF, console apps etc
-* Windows Store apps (universal) for Windows 8.1 and Windows Phone 8.1
 * Windows 8
-* Windows Phone 7.1 and 8
 * WinRT
 * Xamarin.iOS and Xamarin.Mac (Both unified and classic)
 * Xamarin.Android
@@ -454,8 +435,6 @@ property on the event arguments. Setting it to null or empty string will leave t
 The key has a maximum length of 100.
 
 ## Troubleshooting
-
-* If the solution fails to build due to missing dependencies, in Visual Studio 2012 ensure you have the NuGet extension installed and that the Tools -> Options -> Package Manager -> 'Allow NuGet to download missing packages during build' box is checked. Then, go to the directory that you cloned this repository into and run build.bat.
 
 * When installing the package via NuGet into a WinRT project you encounter an error due to an invalid dependency, clone this repository into a directory via Git. Then, open a Powershell or command prompt in the directory location, and run `.\build.bat CompileWinRT`. Then, add the resulting Mindscape.Raygun4Net.WinRT.dll (located in the /release folder) to your project.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Projects built with the following frameworks are supported:
 * .NET 2.0, 3.5, 4.0+
 * .NET 3.5 and 4.0 Client Profile
 * .NET Core 1, 2 (Use the [Mindscape.Raygun4Net.NetCore](https://www.nuget.org/packages/Mindscape.Raygun4Net.NetCore/) package for higher versions)
-* ASP.NET 
+* ASP.NET
 * Mvc
 * WebApi
 * WinForms, WPF, console apps etc

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Where is my app API key?
 
 When sending exceptions to the Raygun service, an app API key is required to map the messages to your application.
 
-When you create a new application in your Raygun dashboard, your app API key is displayed at the top of the instructions page. You can also find the API key by clicking the "Application Settings" button in the side bar of the Raygun dashboard.
+When you create a new application in your Raygun dashboard, your app API key is displayed within the instructions page. You can also find the API key by clicking the "Application Settings" button in the side bar of the Raygun dashboard.
 
 Namespace
 ====================
@@ -233,32 +233,6 @@ private static void Application_ThreadException(object sender, ThreadExceptionEv
 }
 ```
 
-### Windows Store Apps (Windows 8.1 and Windows Phone 8.1)
-
-In the App.xaml.cs constructor (or any central entry point in your application), call the static RaygunClient.Attach method using your API key. This will catch and send all unhandled exception to Raygun for you.
-
-```csharp
-public App()
-{
-  RaygunClient.Attach("YOUR_APP_API_KEY");
-}
-```
-
-At any point after calling the Attach method, you can use RaygunClient.Current to get the static instance. This can be used for manually sending messages (via the Send methods) or changing options such as the User identity string.
-
-You can manually send exceptions with the SendAsync method. When manually sending, currently the compiler does not allow you to use `await` in a catch block. You can however call SendAsync in a blocking way:
-
-```csharp
-try
-{
-  throw new Exception("foo");
-}
-catch (Exception e)
-{
-  RaygunClient.Current.SendAsync(e);
-}
-```
-
 ### WinRT
 
 In the App.xaml.cs constructor (or any main entry point to your application), call the static RaygunClient.Attach method using your API key.
@@ -280,16 +254,6 @@ A workaround for this issue is provided with the Wrap() method. These allow you 
 
 #### Fody
 Another option is to use the [Fody](https://github.com/Fody/Fody) library, and its [AsyncErrorHandler](https://github.com/Fody/AsyncErrorHandler) extension. This will automatically catch async exceptions and pass them to a handler of your choice (which would send to Raygun as above). See the [installation instructions here](https://github.com/Fody/Fody/wiki/SampleUsage), then check out the [sample project](https://github.com/Fody/FodyAddinSamples/tree/master/AsyncErrorHandlerWithRaygun) for how to use.
-
-### Windows Phone 7.1 and 8
-
-In the App.xaml.cs constructor (or any main entry point to your application), call the static RaygunClient.Attach method using your API key.
-
-```csharp
-RaygunClient.Attach("YOUR_APP_API_KEY");
-```
-
-At any point after calling the Attach method, you can use RaygunClient.Current to get the static instance. This can be used for manually sending messages (via the Send methods) or changing options such as the User identity string.
 
 ### Xamarin for Android
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ dotnet add package Mindscape.Raygun4Net
 
 * If you have issues trying to install the package into a WinRT project, see the troubleshooting section below.
 
+---
+See the [Raygun docs](https://raygun.com/documentation/language-guides/dotnet/crash-reporting/net-framework/) for more detailed instructions on how to use this provider.
+
 Supported platforms/frameworks
 ====================
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Raygun4Net
 ==========
 
 [Raygun](http://raygun.com) provider for .NET Framework
-This package is up to date with .NET 7
+This package supports up to .NET 7
 
 Installation
 ====================

--- a/README.md
+++ b/README.md
@@ -2,28 +2,13 @@ Raygun4Net
 ==========
 
 [Raygun](http://raygun.com) provider for .NET Framework
-This package supports up to .NET 7
-
-Installation
-====================
-
-* The easiest way to install this provider is by either using the below dotnet CLI command, or in the NuGet management GUI in the IDE you use.
-
-```
-dotnet add package Mindscape.Raygun4Net
-```
-
-* If you have issues trying to install the package into a WinRT project, see the troubleshooting section below.
-
----
-See the [Raygun docs](https://raygun.com/documentation/language-guides/dotnet/crash-reporting/net-framework/) for more detailed instructions on how to use this provider.
 
 Supported platforms/frameworks
 ====================
 
 Projects built with the following frameworks are supported:
 
-* .NET 2.0, 3.5, 4.0+
+* .NET 2.0, 3.5, 4.0+, up to .NET 7.0
 * .NET 3.5 and 4.0 Client Profile
 * .NET Core 1.0, 2.0, 3.0+
 * ASP.NET
@@ -40,6 +25,21 @@ Install the NuGet package to a project which uses one of the above frameworks an
 For Xamarin we recommended adding either [Raygun4Xamarin.Forms](https://www.nuget.org/packages/Raygun4Xamarin.Forms/), or the [Mindscape.Raygun4Net.Xamarin.Android](https://www.nuget.org/packages/Mindscape.Raygun4Net.Xamarin.Android/) & [Mindscape.Raygun4Net.Xamarin.iOS.Unified](https://www.nuget.org/packages/Mindscape.Raygun4Net.Xamarin.iOS.Unified/) packages.
 
 For .NET Core and .NET versions 5.0 or higher, we recommend using the [Mindscape.Raygun4Net.NetCore](https://www.nuget.org/packages/Mindscape.Raygun4Net.NetCore/) package.
+
+
+Installation
+====================
+
+* The easiest way to install this provider is by either using the below dotnet CLI command, or in the NuGet management GUI in the IDE you use.
+
+```
+dotnet add package Mindscape.Raygun4Net
+```
+
+* If you have issues trying to install the package into a WinRT project, see the troubleshooting section below.
+
+---
+See the [Raygun docs](https://raygun.com/documentation/language-guides/dotnet/crash-reporting/) for more detailed instructions on how to use this provider.
 
 Where is my app API key?
 ====================


### PR DESCRIPTION
This PR is to update the readme for the .NET Core provider so it is up to date

Changes made:

Raygun4Net.NetCore: 
- Updated instructions on how to find API key
- Update installation instructions to match public docs
- Added link to our public docs
- Code formatting

Raygun4Net:
- Add note that package supports up to .NET 7
- Updated instructions on how to find API key
- Added link to our public docs
- Removed ! Important change ! section
- Removed mention of VS NuGet extension
- Removed mention of VS 2008
- Linked to .NET Core package
- Removed mentions of Windows Store and Windows Phone