### PR TITLE
Updating down stream packages (that use raygun4net )

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -43,6 +43,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Mindscape.Raygun4Net.NetCore.Common\Mindscape.Raygun4Net.NetCore.Common.csproj" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <AssemblyOriginatorKeyFile>Raygun4Net.AspNetCore.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <AssemblyOriginatorKeyFile>Raygun4Net.AspNetCore.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Mindscape.Raygun4Net.Azure.WebJob.nuspec
+++ b/Mindscape.Raygun4Net.Azure.WebJob.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Azure.WebJob</id>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Azure.WebJob.nuspec
+++ b/Mindscape.Raygun4Net.Azure.WebJob.nuspec
@@ -2,16 +2,16 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Azure.WebJob</id>
-    <version>5.7.0</version>
+    <version>6.0.1</version>
     <title />
     <authors>Raygun</authors>
     <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for Azure Web Job SDK enabled projects</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
-    <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
-    <dependencies>
+    <license type="file">LICENSE</license>
+    <icon>128x128-transparent.png</icon>
+   <dependencies>
       <dependency id="Mindscape.Raygun4Net.Core" version="5.6.0" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0" />
     </dependencies>
@@ -24,5 +24,7 @@
     <file src="build\webjob\Mindscape.Raygun4Net4.pdb"             target="lib\net40\Mindscape.Raygun4Net4.pdb" />
     
     <file src="Mindscape.Raygun4Net.Azure.WebJob\README.md" />
+    <file src="128x128-transparent.png" />
+    <file src="LICENSE" />
   </files>
 </package>

--- a/Mindscape.Raygun4Net.Azure.WebJob/Mindscape.Raygun4Net.Azure.WebJob.csproj
+++ b/Mindscape.Raygun4Net.Azure.WebJob/Mindscape.Raygun4Net.Azure.WebJob.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>Raygun4Net.Azure.WebJob.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <SignAssembly>true</SignAssembly>

--- a/Mindscape.Raygun4Net.ClientProfile/Mindscape.Raygun4Net.ClientProfile.csproj
+++ b/Mindscape.Raygun4Net.ClientProfile/Mindscape.Raygun4Net.ClientProfile.csproj
@@ -32,7 +32,9 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>    
+    <AssemblyOriginatorKeyFile>Raygun4Net.ClientProfile.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <AssemblyOriginatorKeyFile>Raygun4Net.ClientProfile.snk</AssemblyOriginatorKeyFile>

--- a/Mindscape.Raygun4Net.Common/Mindscape.Raygun4Net.Common.csproj
+++ b/Mindscape.Raygun4Net.Common/Mindscape.Raygun4Net.Common.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net4;net45</TargetFrameworks>
+    <AssemblyOriginatorKeyFile>Raygun4Net4.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup >

--- a/Mindscape.Raygun4Net.Core.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Core.Signed.nuspec
@@ -8,12 +8,15 @@
     <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Core library for signed MVC and WebApi Raygun providers</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
-    <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
-  </metadata>
+    <license type="file">LICENSE</license>
+    <icon>128x128-transparent.png</icon></metadata>
   <files>
     <file src="build\signed\net40\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
     <file src="build\signed\net40\Mindscape.Raygun4Net.pdb" target="lib\net40\Mindscape.Raygun4Net.pdb" />
+ 
+ 
+    <file src="128x128-transparent.png" />
+    <file src="LICENSE" />
   </files>
 </package>

--- a/Mindscape.Raygun4Net.Core.nuspec
+++ b/Mindscape.Raygun4Net.Core.nuspec
@@ -8,12 +8,15 @@
     <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Core library for MVC and WebApi Raygun providers</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
-    <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
+    <license type="file">LICENSE</license>
+    <icon>128x128-transparent.png</icon>
   </metadata>
   <files>
     <file src="build\net40\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
     <file src="build\net40\Mindscape.Raygun4Net.pdb" target="lib\net40\Mindscape.Raygun4Net.pdb" />
+  
+    <file src="128x128-transparent.png" />
+    <file src="LICENSE" />
   </files>
 </package>

--- a/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
+++ b/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <SignAssembly>true</SignAssembly>  
+    <AssemblyOriginatorKeyFile>Raygun4Net.Core.snk</AssemblyOriginatorKeyFile>  
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <SignAssembly>true</SignAssembly>

--- a/Mindscape.Raygun4Net.Mvc.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc.Signed</id>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Mvc.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.Signed.nuspec
@@ -2,16 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc.Signed</id>
-    <version>6.0.0-beta001</version>
+    <version>6.0.1</version>
     <title />
     <authors>Raygun</authors>
     <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for signed ASP.NET MVC projects</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
-    <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
-    <dependencies>
+    <license type="file">LICENSE</license>
+    <icon>128x128-transparent.png</icon><dependencies>
       <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.12.1" />
     </dependencies>
   </metadata>
@@ -23,5 +22,7 @@
     <file src="build\signed\mvc\Mindscape.Raygun4Net4.pdb" target="lib\net40\Mindscape.Raygun4Net4.pdb" />
     
     <file src="Mindscape.Raygun4Net.Mvc\README.md" />
+    <file src="128x128-transparent.png" />
+    <file src="LICENSE" />
   </files>
 </package>

--- a/Mindscape.Raygun4Net.Mvc.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc</id>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Mvc.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.nuspec
@@ -2,15 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc</id>
-    <version>6.0.0-beta001</version>
+    <version>6.0.1</version>
     <title />
     <authors>Raygun</authors>
     <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for ASP.NET MVC projects</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
-    <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
+    <license type="file">LICENSE</license>
+    <icon>128x128-transparent.png</icon>
     <dependencies>
       <dependency id="Mindscape.Raygun4Net.Core" version="5.12.1" />
     </dependencies>
@@ -21,7 +21,11 @@
     <file src="build\mvc\Mindscape.Raygun4Net.Mvc.pdb" target="lib\net40\Mindscape.Raygun4Net.Mvc.pdb" />
     <file src="build\mvc\Mindscape.Raygun4Net4.dll" target="lib\net40\Mindscape.Raygun4Net4.dll" />
     <file src="build\mvc\Mindscape.Raygun4Net4.pdb" target="lib\net40\Mindscape.Raygun4Net4.pdb" />
+    <file src="build\mvc\Mindscape.Raygun4Net.Common.dll" target="lib\net40\Mindscape.Raygun4Net.Common.dll" />
+    <file src="build\mvc\Mindscape.Raygun4Net.Common.pdb" target="lib\net40\Mindscape.Raygun4Net.Common.pdb" />
     
     <file src="Mindscape.Raygun4Net.Mvc\README.md" />
+    <file src="128x128-transparent.png" />
+    <file src="LICENSE" />
   </files>
 </package>

--- a/Mindscape.Raygun4Net.Mvc/Mindscape.Raygun4Net.Mvc.csproj
+++ b/Mindscape.Raygun4Net.Mvc/Mindscape.Raygun4Net.Mvc.csproj
@@ -30,6 +30,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <SignAssembly>true</SignAssembly>    
+    <AssemblyOriginatorKeyFile>Raygun4Net.Mvc.snk</AssemblyOriginatorKeyFile> 
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <SignAssembly>true</SignAssembly>

--- a/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
+++ b/Mindscape.Raygun4Net.NetCore.Common/Mindscape.Raygun4Net.NetCore.Common.csproj
@@ -14,6 +14,8 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</PackageIconUrl>
     <PackageIcon>128x128-transparent.png</PackageIcon>
+    <AssemblyOriginatorKeyFile>Raygun4Net.NetCore.Common.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <PackageId>Mindscape.Raygun4Net.NetCore.Common.Signed</PackageId>

--- a/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
+++ b/Mindscape.Raygun4Net.NetCore/Mindscape.Raygun4Net.NetCore.csproj
@@ -29,6 +29,11 @@
     <Compile Include="RaygunSettings.cs" />
     <Compile Include="Properties\*.cs" />
   </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <AssemblyOriginatorKeyFile>Raygun4Net.NetCore.snk</AssemblyOriginatorKeyFile>
+	  <SignAssembly>true</SignAssembly>
+	  <Optimize>true</Optimize>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <PackageId>Mindscape.Raygun4Net.NetCore.Signed</PackageId>
     <AssemblyOriginatorKeyFile>Raygun4Net.NetCore.snk</AssemblyOriginatorKeyFile>

--- a/Mindscape.Raygun4Net.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Signed</id>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Signed.nuspec
@@ -8,7 +8,6 @@
     <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for signed projects built with .NET Framework</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon>

--- a/Mindscape.Raygun4Net.Tests/Mindscape.Raygun4Net.Tests.csproj
+++ b/Mindscape.Raygun4Net.Tests/Mindscape.Raygun4Net.Tests.csproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>Mindscape.Raygun4Net.Tests.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Mindscape.Raygun4Net.Tests.snk</AssemblyOriginatorKeyFile>

--- a/Mindscape.Raygun4Net.WebApi.Signed.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.Signed.nuspec
@@ -9,10 +9,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Raygun provider for signed ASP.NET Web API projects</summary>
     <description>Raygun provider for signed ASP.NET Web API projects</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
-    <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
-    <dependencies>
+    <license type="file">LICENSE</license>
+    <icon>128x128-transparent.png</icon>  <dependencies>
       <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.12.1" />
     </dependencies>
   </metadata>
@@ -21,5 +20,7 @@
     <file src="build\signed\webapi\Mindscape.Raygun4Net.WebApi.pdb" target="lib\net45\Mindscape.Raygun4Net.WebApi.pdb" />
     
     <file src="Mindscape.Raygun4Net.WebApi\README.md" />
+    <file src="128x128-transparent.png" />
+    <file src="LICENSE" />
   </files>
 </package>

--- a/Mindscape.Raygun4Net.WebApi.Signed.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.Signed.nuspec
@@ -11,7 +11,8 @@
     <description>Raygun provider for signed ASP.NET Web API projects</description>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <license type="file">LICENSE</license>
-    <icon>128x128-transparent.png</icon>  <dependencies>
+    <icon>128x128-transparent.png</icon>
+    <dependencies>
       <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.12.1" />
     </dependencies>
   </metadata>

--- a/Mindscape.Raygun4Net.WebApi.Tests/Mindscape.Raygun4Net.WebApi.Tests.csproj
+++ b/Mindscape.Raygun4Net.WebApi.Tests/Mindscape.Raygun4Net.WebApi.Tests.csproj
@@ -70,9 +70,7 @@
       <Name>Mindscape.Raygun4Net.WebApi</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Payloads\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <EmbeddedResource Include="Payloads\AttributedWithoutValues.xml" />
     <EmbeddedResource Include="Payloads\AttributedWithValues.xml" />

--- a/Mindscape.Raygun4Net.WebApi.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.nuspec
@@ -9,9 +9,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Raygun provider for ASP.NET Web API projects</summary>
     <description>Raygun provider for ASP.NET Web API projects</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
-    <licenseUrl>https://raw.github.com/MindscapeHQ/raygun4net/master/LICENSE</licenseUrl>
+    <license type="file">LICENSE</license>
+    <icon>128x128-transparent.png</icon> 
     <dependencies>
       <dependency id="Mindscape.Raygun4Net.Core" version="5.12.1" />
     </dependencies>
@@ -21,5 +21,7 @@
     <file src="build\webapi\Mindscape.Raygun4Net.WebApi.pdb" target="lib\net45\Mindscape.Raygun4Net.WebApi.pdb" />
     
     <file src="Mindscape.Raygun4Net.WebApi\README.md" />
+    <file src="128x128-transparent.png" />
+    <file src="LICENSE" />
   </files>
 </package>

--- a/Mindscape.Raygun4Net.WebApi.sln
+++ b/Mindscape.Raygun4Net.WebApi.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33626.354
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mindscape.Raygun4Net.WebApi", "Mindscape.Raygun4Net.WebApi\Mindscape.Raygun4Net.WebApi.csproj", "{5F72C401-B09D-46C4-873B-65F1B4B1AE09}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mindscape.Raygun4Net.Core", "Mindscape.Raygun4Net.Core\Mindscape.Raygun4Net.Core.csproj", "{6435C84C-1DAC-41FE-AA51-FAA8E9A7F090}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mindscape.Raygun4Net.WebApi.Tests", "Mindscape.Raygun4Net.WebApi.Tests\Mindscape.Raygun4Net.WebApi.Tests.csproj", "{80C7BB59-C753-4E64-9C8D-79B8D57C8215}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mindscape.Raygun4Net.Common", "Mindscape.Raygun4Net.Common\Mindscape.Raygun4Net.Common.csproj", "{07BC7731-D359-4D64-A55A-105FF387858C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,6 +36,12 @@ Global
 		{80C7BB59-C753-4E64-9C8D-79B8D57C8215}.Release|Any CPU.Build.0 = Release|Any CPU
 		{80C7BB59-C753-4E64-9C8D-79B8D57C8215}.Sign|Any CPU.ActiveCfg = Release|Any CPU
 		{80C7BB59-C753-4E64-9C8D-79B8D57C8215}.Sign|Any CPU.Build.0 = Release|Any CPU
+		{07BC7731-D359-4D64-A55A-105FF387858C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07BC7731-D359-4D64-A55A-105FF387858C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07BC7731-D359-4D64-A55A-105FF387858C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07BC7731-D359-4D64-A55A-105FF387858C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07BC7731-D359-4D64-A55A-105FF387858C}.Sign|Any CPU.ActiveCfg = Debug|Any CPU
+		{07BC7731-D359-4D64-A55A-105FF387858C}.Sign|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
+++ b/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
@@ -32,6 +32,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>Raygun4Net.WebApi.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <SignAssembly>true</SignAssembly>

--- a/Mindscape.Raygun4Net.nuspec
+++ b/Mindscape.Raygun4Net.nuspec
@@ -3,14 +3,13 @@
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net</id>
     <version>6.0.1</version>
-    <title />
     <authors>Raygun</authors>
-    <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for .NET Framework</description>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon>
+    <tags>Raygun debugging error monitoring error tracking bug tracking</tags>
   </metadata>
   <files>
     <!-- .NET 4.0 -->

--- a/Mindscape.Raygun4Net.nuspec
+++ b/Mindscape.Raygun4Net.nuspec
@@ -8,7 +8,6 @@
     <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for .NET Framework</description>
-    <iconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</iconUrl>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon>

--- a/Mindscape.Raygun4Net.nuspec
+++ b/Mindscape.Raygun4Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net</id>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <authors>Raygun</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for .NET Framework</description>

--- a/Mindscape.Raygun4Net/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.1.0")]
-[assembly: AssemblyFileVersion("6.0.1.0")]
+[assembly: AssemblyVersion("6.0.2.0")]
+[assembly: AssemblyFileVersion("6.0.2.0")]

--- a/Mindscape.Raygun4Net4.ClientProfile/Mindscape.Raygun4Net4.ClientProfile.csproj
+++ b/Mindscape.Raygun4Net4.ClientProfile/Mindscape.Raygun4Net4.ClientProfile.csproj
@@ -29,6 +29,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>Raygun4Net4.ClientProfile.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <SignAssembly>true</SignAssembly>

--- a/Mindscape.Raygun4Net4.Nuget.Tests/Mindscape.Raygun4Net4.Nuget.Tests.csproj
+++ b/Mindscape.Raygun4Net4.Nuget.Tests/Mindscape.Raygun4Net4.Nuget.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.0" />
+    <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1">

--- a/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
+++ b/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AssemblyOriginatorKeyFile>Raygun4Net4.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sign|AnyCPU' ">
     <AssemblyOriginatorKeyFile>Raygun4Net4.snk</AssemblyOriginatorKeyFile>

--- a/Mindscape.Raygun4Net4/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net4/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.1.0")]
-[assembly: AssemblyFileVersion("6.0.1.0")]
+[assembly: AssemblyVersion("6.0.2.0")]
+[assembly: AssemblyFileVersion("6.0.2.0")]

--- a/build.ps1
+++ b/build.ps1
@@ -8,21 +8,22 @@ properties {
     $solution_file_mvc =          "$root/Mindscape.Raygun4Net.Mvc.sln"
     $solution_file_webapi =       "$root/Mindscape.Raygun4Net.WebApi.sln"
     $solution_file_webjob =       "$root/Mindscape.Raygun4Net.Azure.WebJob.sln"
-    $configuration =              "Sign" ## We can sign the regular packages too
-    $configurationOld =           "Release" ## Update some time in the future
+    $solution_file_winrt =        "$root/Mindscape.Raygun4Net.WinRT.sln"
+    $configuration =              "Release"
     $build_dir =                  "$root\build\"
     $build_dir_net4 =             "$build_dir\net40"
     $build_dir_net4_client =      "$build_dir\net40-client"
     $build_dir_mvc =              "$build_dir\mvc"
     $build_dir_webapi =           "$build_dir\webapi"
     $build_dir_webjob =           "$build_dir\webjob"
+   # $build_dir_winrt =            "$build_dir\winrt"
     $nunit_dir =                  "$root\packages\NUnit.Runners.2.6.2\tools\"
     $tools_dir =                  "$root\tools"
     $nuget_dir =                  "$root\.nuget"
     $env:Path +=                  ";$nunit_dir;$tools_dir;$nuget_dir"
 }
 
-task default -depends Compile 
+task default -depends Compile #, CompileWinRT
 
 task Clean {
     remove-item -force -recurse $build_dir -ErrorAction SilentlyContinue | Out-Null
@@ -36,15 +37,22 @@ task Compile -depends Init {
     
     exec { msbuild "$solution_file_net4"   /p:OutDir=$build_dir_net4 /p:Configuration=$configuration }
     exec { msbuild "$solution_file_net4_client" /m /p:OutDir=$build_dir_net4_client /p:Configuration=$configuration }
-
-    exec { msbuild "$solution_file_mvc" /m /p:OutDir=$build_dir_mvc /p:Configuration=$configurationOld }
-    exec { msbuild "$solution_file_webapi" /m /p:OutDir=$build_dir_webapi /p:Configuration=$configurationOld }
-    exec { msbuild "$solution_file_webjob" /m /p:OutDir=$build_dir_webjob /p:Configuration=$configurationOld }
+    exec { msbuild "$solution_file_mvc" /m /p:OutDir=$build_dir_mvc /p:Configuration=$configuration }
+    exec { msbuild "$solution_file_webapi" /m /p:OutDir=$build_dir_webapi /p:Configuration=$configuration }
+    exec { msbuild "$solution_file_webjob" /m /p:OutDir=$build_dir_webjob /p:Configuration=$configuration }
 }
 
+ task CompileWinRT -depends Init {
+     exec { msbuild "$solution_file_winrt" /m /p:OutDir=$build_dir_winrt /p:Configuration=$configuration }
+     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT/Mindscape.Raygun4Net.WinRT.dll $build_dir_winrt
+     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT/Mindscape.Raygun4Net.WinRT.pdb $build_dir_winrt
+     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT.Tests/Mindscape.Raygun4Net.WinRT.Tests.dll $build_dir_winrt
+     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT.Tests/Mindscape.Raygun4Net.WinRT.Tests.pdb $build_dir_winrt
+     remove-item -force -recurse $build_dir_winrt/Mindscape.Raygun4Net.WinRT -ErrorAction SilentlyContinue | Out-Null
+     remove-item -force -recurse $build_dir_winrt/Mindscape.Raygun4Net.WinRT.Tests -ErrorAction SilentlyContinue | Out-Null
+}
 
-
-task Test -depends Compile {
+task Test -depends Compile, CompileWinRT {
     $test_assemblies = Get-ChildItem $build_dir -Include *Tests.dll -Name
 
     Push-Location -Path $build_dir

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,6 @@ properties {
     $solution_file_mvc =          "$root/Mindscape.Raygun4Net.Mvc.sln"
     $solution_file_webapi =       "$root/Mindscape.Raygun4Net.WebApi.sln"
     $solution_file_webjob =       "$root/Mindscape.Raygun4Net.Azure.WebJob.sln"
-    $solution_file_winrt =        "$root/Mindscape.Raygun4Net.WinRT.sln"
     $configuration =              "Release"
     $build_dir =                  "$root\build\"
     $build_dir_net4 =             "$build_dir\net40"
@@ -16,14 +15,13 @@ properties {
     $build_dir_mvc =              "$build_dir\mvc"
     $build_dir_webapi =           "$build_dir\webapi"
     $build_dir_webjob =           "$build_dir\webjob"
-   # $build_dir_winrt =            "$build_dir\winrt"
     $nunit_dir =                  "$root\packages\NUnit.Runners.2.6.2\tools\"
     $tools_dir =                  "$root\tools"
     $nuget_dir =                  "$root\.nuget"
     $env:Path +=                  ";$nunit_dir;$tools_dir;$nuget_dir"
 }
 
-task default -depends Compile #, CompileWinRT
+task default -depends Compile
 
 task Clean {
     remove-item -force -recurse $build_dir -ErrorAction SilentlyContinue | Out-Null
@@ -42,17 +40,9 @@ task Compile -depends Init {
     exec { msbuild "$solution_file_webjob" /m /p:OutDir=$build_dir_webjob /p:Configuration=$configuration }
 }
 
- task CompileWinRT -depends Init {
-     exec { msbuild "$solution_file_winrt" /m /p:OutDir=$build_dir_winrt /p:Configuration=$configuration }
-     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT/Mindscape.Raygun4Net.WinRT.dll $build_dir_winrt
-     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT/Mindscape.Raygun4Net.WinRT.pdb $build_dir_winrt
-     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT.Tests/Mindscape.Raygun4Net.WinRT.Tests.dll $build_dir_winrt
-     move-item $build_dir_winrt/Mindscape.Raygun4Net.WinRT.Tests/Mindscape.Raygun4Net.WinRT.Tests.pdb $build_dir_winrt
-     remove-item -force -recurse $build_dir_winrt/Mindscape.Raygun4Net.WinRT -ErrorAction SilentlyContinue | Out-Null
-     remove-item -force -recurse $build_dir_winrt/Mindscape.Raygun4Net.WinRT.Tests -ErrorAction SilentlyContinue | Out-Null
-}
 
-task Test -depends Compile, CompileWinRT {
+
+task Test -depends Compile {
     $test_assemblies = Get-ChildItem $build_dir -Include *Tests.dll -Name
 
     Push-Location -Path $build_dir


### PR DESCRIPTION
Updating down stream packages 

Also updated:

1. package number
2.  icon,
3.  licence (refence)
4. signed the regular packages signed (so we can deprecate the `<xyz>.Signed` packages later