### PR TITLE
bump all the versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ xpkg
 *.xam
 .idea/
 to-upload/
+*.orig

--- a/AssemblyVersionInfo.cs
+++ b/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.12.1.0")]
-[assembly: AssemblyFileVersion("5.12.1.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net.Azure.WebJob.nuspec
+++ b/Mindscape.Raygun4Net.Azure.WebJob.nuspec
@@ -12,7 +12,7 @@
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon>
    <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core" version="5.6.0" />
+      <dependency id="Mindscape.Raygun4Net.Core" version="6.0.3" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0" />
     </dependencies>
   </metadata>

--- a/Mindscape.Raygun4Net.Azure.WebJob.nuspec
+++ b/Mindscape.Raygun4Net.Azure.WebJob.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Azure.WebJob</id>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Azure.WebJob/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.Azure.WebJob/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.12.1.0")]
-[assembly: AssemblyFileVersion("5.12.1.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net.ClientProfile/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.ClientProfile/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.12.1.0")]
-[assembly: AssemblyFileVersion("5.12.1.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net.Core.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Core.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Core.Signed</id>
-    <version>5.12.1</version>
+    <version>6.0.3</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Core.nuspec
+++ b/Mindscape.Raygun4Net.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Core</id>
-    <version>5.12.1</version>
+    <version>6.0.3</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.Core/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.Core/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.12.1.0")]
-[assembly: AssemblyFileVersion("5.12.1.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net.Mvc.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc.Signed</id>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <title />
     <authors>Raygun</authors>
     <owners />
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon><dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.12.1" />
+      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="6.0.3" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.Mvc.nuspec
+++ b/Mindscape.Raygun4Net.Mvc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Mvc</id>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <title />
     <authors>Raygun</authors>
     <owners />
@@ -12,7 +12,7 @@
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon>
     <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core" version="5.12.1" />
+      <dependency id="Mindscape.Raygun4Net.Core" version="6.0.3" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.Mvc/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.Mvc/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.12.1.0")]
-[assembly: AssemblyFileVersion("5.12.1.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net.Signed.nuspec
+++ b/Mindscape.Raygun4Net.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.Signed</id>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <title />
     <authors>Raygun</authors>
     <owners />

--- a/Mindscape.Raygun4Net.WebApi.Signed.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.Signed.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.WebApi.Signed</id>
-    <version>5.11.1</version>
+    <version>6.0.3</version>
     <title>Raygun for ASP.NET Web API</title>
     <authors>Raygun</authors>
     <owners />
@@ -13,7 +13,7 @@
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon>
     <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="5.12.1" />
+      <dependency id="Mindscape.Raygun4Net.Core.Signed" version="6.0.3" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.WebApi.nuspec
+++ b/Mindscape.Raygun4Net.WebApi.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net.WebApi</id>
-    <version>5.11.1</version>
+    <version>6.0.3</version>
     <title>Raygun for ASP.NET Web API</title>
     <authors>Raygun</authors>
     <owners />
@@ -13,7 +13,7 @@
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon> 
     <dependencies>
-      <dependency id="Mindscape.Raygun4Net.Core" version="5.12.1" />
+      <dependency id="Mindscape.Raygun4Net.Core" version="6.0.3" />
     </dependencies>
   </metadata>
   <files>

--- a/Mindscape.Raygun4Net.WebApi/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net.WebApi/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.11.1.0")]
-[assembly: AssemblyFileVersion("5.11.1.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net.nuspec
+++ b/Mindscape.Raygun4Net.nuspec
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Mindscape.Raygun4Net</id>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <authors>Raygun</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Raygun provider for .NET Framework</description>
     <projectUrl>https://github.com/MindscapeHQ/raygun4net</projectUrl>
     <license type="file">LICENSE</license>
     <icon>128x128-transparent.png</icon>
-    <tags>Raygun debugging error monitoring error tracking bug tracking</tags>
+    <tags>Raygun debugging error monitoring bug tracking</tags>
   </metadata>
   <files>
     <!-- .NET 4.0 -->

--- a/Mindscape.Raygun4Net/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.2.0")]
-[assembly: AssemblyFileVersion("6.0.2.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net4.ClientProfile/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net4.ClientProfile/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.12.1.0")]
-[assembly: AssemblyFileVersion("5.12.1.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/Mindscape.Raygun4Net4.Nuget.Tests/Mindscape.Raygun4Net4.Nuget.Tests.csproj
+++ b/Mindscape.Raygun4Net4.Nuget.Tests/Mindscape.Raygun4Net4.Nuget.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.2" />
+    <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1">

--- a/Mindscape.Raygun4Net4.Nuget.Tests/Mindscape.Raygun4Net4.Nuget.Tests.csproj
+++ b/Mindscape.Raygun4Net4.Nuget.Tests/Mindscape.Raygun4Net4.Nuget.Tests.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.2" />
     <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/Mindscape.Raygun4Net4/Properties/AssemblyVersionInfo.cs
+++ b/Mindscape.Raygun4Net4/Properties/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.2.0")]
-[assembly: AssemblyFileVersion("6.0.2.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]


### PR DESCRIPTION
Bump version numbers

When a sln references several raygun4net packages  the raygun4net.dll can have version conflicts.

To resolve this we could do a bit of a rebuild of the nuget packages (maybe later) or just bump the version numbers so they all will use the same dlls 