### PR TITLE
Fixed global.json file to minor versions and no pre-releases

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.*"
+    "version": "6.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Version was causing Rider to use .NET 8 as it didn't understand the `Version`

https://learn.microsoft.com/en-us/dotnet/core/tools/global-json

Changed to specify v6 and allow any Minor version, but disallow pre-releases. 