### PR TITLE
Adjust Nuspec to fix wrong dll being packaged

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,8 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v7.0.1
+- Fixed nuspec packaging wrong files
+
 ### v7.0.0
 - Correctly populate missing Environment Information
 - Deprecated .Signed suffix packages

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -3,5 +3,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyFileVersion("")]
-[assembly: AssemblyInformationalVersion("")]
+[assembly: AssemblyFileVersion("7.0.1")]
+[assembly: AssemblyInformationalVersion("7.0.1")]

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -3,5 +3,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyFileVersion("7.0.1")]
-[assembly: AssemblyInformationalVersion("7.0.1")]
+[assembly: AssemblyFileVersion("7.0.0")]
+[assembly: AssemblyInformationalVersion("7.0.0")]

--- a/nuspecs/Mindscape.Raygun4Net.Core.nuspec
+++ b/nuspecs/Mindscape.Raygun4Net.Core.nuspec
@@ -17,7 +17,7 @@
 
   </metadata>
   <files>
-    <file src="..\Mindscape.Raygun4Net\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
+    <file src="..\Mindscape.Raygun4Net.Core\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
   
     <file src="..\128x128-transparent.png" target="128x128-transparent.png" />
     <file src="..\LICENSE" target="LICENSE" />

--- a/nuspecs/Mindscape.Raygun4Net.nuspec
+++ b/nuspecs/Mindscape.Raygun4Net.nuspec
@@ -19,8 +19,8 @@
   <files>
     <!-- .NET 4.0 -->
     <file src="..\Mindscape.Raygun4Net4\bin\Release\Mindscape.Raygun4Net4.dll" target="lib\net40\Mindscape.Raygun4Net4.dll" />
-    <file src="..\Mindscape.Raygun4Net4\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
-    <file src="..\Mindscape.Raygun4Net4\bin\Release\Mindscape.Raygun4Net.Common.dll" target="lib\net40\Mindscape.Raygun4Net.Common.dll" />
+    <file src="..\Mindscape.Raygun4Net.Core\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
+    <file src="..\Mindscape.Raygun4Net.Common\bin\Release\net4\Mindscape.Raygun4Net.Common.dll" target="lib\net40\Mindscape.Raygun4Net.Common.dll" />
     <!-- .NET 4.0 Client Profile -->
     <file src="..\Mindscape.Raygun4Net\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40-client\Mindscape.Raygun4Net.dll" />
     <file src="..\Mindscape.Raygun4Net.Common\bin\Release\net4\Mindscape.Raygun4Net.Common.dll" target="lib\net40-client\Mindscape.Raygun4Net.Common.dll" />

--- a/nuspecs/Mindscape.Raygun4Net.nuspec
+++ b/nuspecs/Mindscape.Raygun4Net.nuspec
@@ -19,8 +19,8 @@
   <files>
     <!-- .NET 4.0 -->
     <file src="..\Mindscape.Raygun4Net4\bin\Release\Mindscape.Raygun4Net4.dll" target="lib\net40\Mindscape.Raygun4Net4.dll" />
-    <file src="..\Mindscape.Raygun4Net\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
-    <file src="..\Mindscape.Raygun4Net.Common\bin\Release\net4\Mindscape.Raygun4Net.Common.dll" target="lib\net40\Mindscape.Raygun4Net.Common.dll" />
+    <file src="..\Mindscape.Raygun4Net4\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40\Mindscape.Raygun4Net.dll" />
+    <file src="..\Mindscape.Raygun4Net4\bin\Release\Mindscape.Raygun4Net.Common.dll" target="lib\net40\Mindscape.Raygun4Net.Common.dll" />
     <!-- .NET 4.0 Client Profile -->
     <file src="..\Mindscape.Raygun4Net\bin\Release\Mindscape.Raygun4Net.dll" target="lib\net40-client\Mindscape.Raygun4Net.dll" />
     <file src="..\Mindscape.Raygun4Net.Common\bin\Release\net4\Mindscape.Raygun4Net.Common.dll" target="lib\net40-client\Mindscape.Raygun4Net.Common.dll" />

--- a/pack-all.ps1
+++ b/pack-all.ps1
@@ -14,7 +14,7 @@ properties {
 task default -depends Pack
 
 task Clean {
-    remove-item -force -recurse $build_dir -ErrorAction SilentlyContinue | Out-Null
+    #remove-item -force -recurse $build_dir -ErrorAction SilentlyContinue | Out-Null
 }
 
 task Build -depends Clean {

--- a/pack-all.ps1
+++ b/pack-all.ps1
@@ -14,7 +14,7 @@ properties {
 task default -depends Pack
 
 task Clean {
-    #remove-item -force -recurse $build_dir -ErrorAction SilentlyContinue | Out-Null
+    remove-item -force -recurse $build_dir -ErrorAction SilentlyContinue | Out-Null
 }
 
 task Build -depends Clean {

--- a/pack-all.ps1
+++ b/pack-all.ps1
@@ -6,7 +6,7 @@ properties {
     $build_dir = "$root\build"
     $nuget_dir = "$root\.nuget"
     $nuspec_folder = "$root\nuspecs"
-    $version = "7.0.0"
+    $version = "7.0.1"
     $include_signed = $true
     $global_assembly_info = ".\GlobalAssemblyInfo.cs" 
 }


### PR DESCRIPTION
When migrating all the nuspecs i packaged the wrong one. Mindscape.Raygun4Net.Core is actually built as Mindscape.Raygun4Net so 2 packages were being bundled with the wrong dll. This has been fixed and deployed to Nuget already as 7.0.1