### PR TITLE
Remove Common ref on WebApi

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,8 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v7.1.1 (Mindscape.Raygun4Net.WebApi)
+- Fixed issue with missing dependency on `Mindscape.Raygun4Net.Common`
+
 ### v7.1.0
 - Fixed Environment Information Memory
 - Added cache for Environment Information to reduce overhead

--- a/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
+++ b/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
@@ -61,6 +61,15 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Mindscape.Raygun4Net.Common\DataAccess\IHttpClient.cs">
+      <Link>IHttpClient.cs</Link>
+    </Compile>
+    <Compile Include="..\Mindscape.Raygun4Net.Common\DataAccess\RaygunWebClient.cs">
+      <Link>RaygunWebClient.cs</Link>
+    </Compile>
+    <Compile Include="..\Mindscape.Raygun4Net.Common\DataAccess\WebClientFacade.cs">
+      <Link>WebClientFacade.cs</Link>
+    </Compile>
     <Compile Include="..\Mindscape.Raygun4Net4\WebClientHelper.cs">
       <Link>WebClientHelper.cs</Link>
     </Compile>
@@ -84,10 +93,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Mindscape.Raygun4Net.Common\Mindscape.Raygun4Net.Common.csproj">
-      <Project>{f6087df7-625d-45f7-af91-a0c53da312f1}</Project>
-      <Name>Mindscape.Raygun4Net.Common</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Mindscape.Raygun4Net.Core\Mindscape.Raygun4Net.Core.csproj">
       <Project>{6435c84c-1dac-41fe-aa51-faa8e9a7f090}</Project>
       <Name>Mindscape.Raygun4Net.Core</Name>


### PR DESCRIPTION
Removed the reference to `Mindscape.Raygun4Net.Common` and Linked the 3 dependent files into the WebApi project.

I double checked the old nuget packages and they have no reference to Common. 

This resolves a bug raised on the forum: https://raygun.com/forums/thread/184633

Release v7.1.1 for WebApi was built off the branch and release to nuget. 