### PR TITLE
Convert the GlobalExceptionBridge to use WeakReference for events

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,8 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v8.2.1
+- Fixed memory leak when multiple RaygunClient instances are created
+
 ### v8.2.0
 - Added public ctor to allow RaygunClient to accept a custom HttpClient
 - Changed the default timeout of HttpClient from 100 seconds to 30 seconds

--- a/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
@@ -109,7 +109,7 @@ namespace Mindscape.Raygun4Net
         ApplicationVersion = settings.ApplicationVersion;
       }
 
-      UnhandledExceptionBridge.OnUnhandledException += OnApplicationUnhandledException;
+      UnhandledExceptionBridge.OnUnhandledException(OnApplicationUnhandledException);
     }
 
     public RaygunClientBase(RaygunSettingsBase settings) : this(settings, DefaultClient)

--- a/Mindscape.Raygun4Net.NetCore.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/Model/FakeRaygunClient.cs
@@ -21,6 +21,11 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
             : base(apiKey)
         {
         }
+        
+        public FakeRaygunClient(RaygunSettings settings)
+          : base(settings)
+        {
+        }
 
         public RaygunMessage ExposeBuildMessage(Exception exception, [Optional] IList<string> tags, [Optional] IDictionary userCustomData, [Optional] RaygunIdentifierMessage user)
         {

--- a/Mindscape.Raygun4Net.NetCore.Tests/RaygunClientBaseTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/RaygunClientBaseTests.cs
@@ -1,59 +1,104 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using NUnit.Framework;
 
 namespace Mindscape.Raygun4Net.NetCore.Tests
 {
-    [TestFixture]
-    public class RaygunClientBaseTests
+  [TestFixture]
+  public class RaygunClientBaseTests
+  {
+    private FakeRaygunClient _client = new FakeRaygunClient();
+
+    [Test]
+    public void FlagAsSentDoesNotCrash_DataDoesNotSupportStringKeys()
     {
-        private FakeRaygunClient _client = new FakeRaygunClient();
-
-        [Test]
-        public void FlagAsSentDoesNotCrash_DataDoesNotSupportStringKeys()
-        {
-            Assert.That(() => _client.ExposeFlagAsSent(new FakeException(new Dictionary<int, object>())), Throws.Nothing);
-        }
-
-        [Test]
-        public void FlagAsSentDoesNotCrash_NullData()
-        {
-            Assert.That(() => _client.ExposeFlagAsSent(new FakeException(null)), Throws.Nothing);
-        }
-
-        [Test]
-        public void CanSendIfDataIsNull()
-        {
-            Assert.IsTrue(_client.ExposeCanSend(new FakeException(null)));
-        }
-
-        [Test]
-        public void CannotSendSentException_StringDictionary()
-        {
-            Exception exception = new FakeException(new Dictionary<string, object>());
-            _client.ExposeFlagAsSent(exception);
-            Assert.IsFalse(_client.ExposeCanSend(exception));
-        }
-
-        [Test]
-        public void CannotSendSentException_ObjectDictionary()
-        {
-            Exception exception = new FakeException(new Dictionary<object, object>());
-            _client.ExposeFlagAsSent(exception);
-            Assert.IsFalse(_client.ExposeCanSend(exception));
-        }
-
-        [Test]
-        public void ExceptionInsideSendingMessageHAndlerDoesNotCrash()
-        {
-            FakeRaygunClient client = new FakeRaygunClient();
-            client.SendingMessage += (sender, args) =>
-            {
-                throw new Exception("Oops...");
-            };
-
-            Assert.That(() => client.ExposeOnSendingMessage(new RaygunMessage()), Throws.Nothing);
-            Assert.IsTrue(client.ExposeOnSendingMessage(new RaygunMessage()));
-        }
+      Assert.That(() => _client.ExposeFlagAsSent(new FakeException(new Dictionary<int, object>())), Throws.Nothing);
     }
+
+    [Test]
+    public void FlagAsSentDoesNotCrash_NullData()
+    {
+      Assert.That(() => _client.ExposeFlagAsSent(new FakeException(null)), Throws.Nothing);
+    }
+
+    [Test]
+    public void CanSendIfDataIsNull()
+    {
+      Assert.IsTrue(_client.ExposeCanSend(new FakeException(null)));
+    }
+
+    [Test]
+    public void CannotSendSentException_StringDictionary()
+    {
+      Exception exception = new FakeException(new Dictionary<string, object>());
+      _client.ExposeFlagAsSent(exception);
+      Assert.IsFalse(_client.ExposeCanSend(exception));
+    }
+
+    [Test]
+    public void CannotSendSentException_ObjectDictionary()
+    {
+      Exception exception = new FakeException(new Dictionary<object, object>());
+      _client.ExposeFlagAsSent(exception);
+      Assert.IsFalse(_client.ExposeCanSend(exception));
+    }
+
+    [Test]
+    public void ExceptionInsideSendingMessageHAndlerDoesNotCrash()
+    {
+      FakeRaygunClient client = new FakeRaygunClient();
+      client.SendingMessage += (sender, args) => { throw new Exception("Oops..."); };
+
+      Assert.That(() => client.ExposeOnSendingMessage(new RaygunMessage()), Throws.Nothing);
+      Assert.IsTrue(client.ExposeOnSendingMessage(new RaygunMessage()));
+    }
+
+    [Test]
+    public void RaygunClient_DoesNotCauseMemoryLeak_WhenUnhandledExceptionsAreSubscribed()
+    {
+      var weakRef = null as WeakReference;
+
+      new Action(() =>
+      {
+        // Run this in a delegate to that the local variable gets garbage collected
+        var client = new FakeRaygunClient();
+        weakRef = new WeakReference(client);
+      })();
+
+      UnhandledExceptionBridge.RaiseUnhandledException(new Exception("Something bad"), false);
+      Assert.That(weakRef.IsAlive, Is.True);
+
+      // Force a GC
+      GC.Collect();
+      GC.WaitForPendingFinalizers();
+      GC.Collect();
+
+      Assert.IsFalse(weakRef.IsAlive);
+    }
+
+    [Test]
+    public void RaygunClient_Works_WhenUnhandledExceptionsAreSubscribed()
+    {
+      RaygunMessage message = null;
+      var manualResetEvent = new ManualResetEvent(false);
+      var client = new FakeRaygunClient(new RaygunSettings
+      {
+        ApiKey = "test",
+        CatchUnhandledExceptions = true
+      });
+
+      client.SendingMessage += (sender, args) =>
+      {
+        message = args.Message;
+        manualResetEvent.Set();
+      };
+
+      UnhandledExceptionBridge.RaiseUnhandledException(new Exception("Something bad"), false);
+
+      manualResetEvent.WaitOne(5000);
+
+      Assert.That(message, Is.Not.Null);
+    }
+  }
 }


### PR DESCRIPTION
This is to fix #508 

Use WeakReference to wrap the event subcribers.

This allows for multiple RaygunClient instances, and they are no longer kept alive by the event subscription.