### PR TITLE
Convert the multicast delegate into a list of handlers

### DIFF
--- a/Mindscape.Raygun4Net.NetCore.Common/UnhandledExceptionBridge.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/UnhandledExceptionBridge.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Mindscape.Raygun4Net.Platforms;
 
@@ -7,10 +10,11 @@ namespace Mindscape.Raygun4Net
   public static class UnhandledExceptionBridge
   {
     internal delegate void UnhandledExceptionHandler(Exception exception, bool isTerminating);
-    
-    // We'll route all unhandled exceptions through this one event, from there the RaygunClient
-    // can determine whether to send them or not
-    private static event UnhandledExceptionHandler UnhandledExceptionEvent;
+
+    private static readonly List<WeakExceptionHandler> Handlers = new List<WeakExceptionHandler>();
+
+    private static readonly ReaderWriterLockSlim HandlersLock =
+      new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
     static UnhandledExceptionBridge()
     {
@@ -20,21 +24,28 @@ namespace Mindscape.Raygun4Net
         RaiseUnhandledException(args.ExceptionObject as Exception, args.IsTerminating);
       };
 
-      TaskScheduler.UnobservedTaskException += (sender, args) =>
-      {
-        RaiseUnhandledException(args.Exception, false);
-      };
-      
+      TaskScheduler.UnobservedTaskException += (sender, args) => { RaiseUnhandledException(args.Exception, false); };
+
       // Try attach platform specific exceptions
       WindowsPlatform.TryAttachExceptionHandlers();
       AndroidPlatform.TryAttachExceptionHandlers();
       ApplePlatform.TryAttachExceptionHandlers();
-
     }
-    
+
     public static void RaiseUnhandledException(Exception exception, bool isTerminating)
     {
-      UnhandledExceptionEvent?.Invoke(exception, isTerminating);
+      HandlersLock.EnterReadLock();
+      try
+      {
+        foreach (var handler in Handlers)
+        {
+          handler.Invoke(exception, isTerminating);
+        }
+      }
+      finally
+      {
+        HandlersLock.ExitReadLock();
+      }
     }
 
     internal static void OnUnhandledException(UnhandledExceptionHandler callback)
@@ -42,8 +53,48 @@ namespace Mindscape.Raygun4Net
       // Wrap the callback in a weak reference container
       // Then subscribe to the event using the weak reference
       // The onDestroyed function is called - and unregisters it from the multicast delegate
-      var weakHandler = new WeakExceptionHandler(callback, w => UnhandledExceptionEvent -= w.Handle);
-      UnhandledExceptionEvent += weakHandler.Handle;
+      var weakHandler = new WeakExceptionHandler(callback, RemoveDeadHandler);
+
+      HandlersLock.EnterWriteLock();
+      try
+      {
+        Handlers.Add(weakHandler);
+        RemoveDeadHandlers();
+      }
+      finally
+      {
+        HandlersLock.ExitWriteLock();
+      }
+    }
+
+    private static void RemoveDeadHandler(WeakExceptionHandler handler)
+    {
+      HandlersLock.EnterWriteLock();
+      try
+      {
+        Handlers.Remove(handler);
+      }
+      finally
+      {
+        HandlersLock.ExitWriteLock();
+      }
+    }
+
+    private static void RemoveDeadHandlers()
+    {
+      HandlersLock.EnterWriteLock();
+      try
+      {
+        var handlersToRemove = Handlers.Where(x => !x.IsAlive).ToList();
+        foreach (var handler in handlersToRemove)
+        {
+          RemoveDeadHandler(handler);
+        }
+      }
+      finally
+      {
+        HandlersLock.ExitWriteLock();
+      }
     }
 
     private class WeakExceptionHandler
@@ -51,13 +102,15 @@ namespace Mindscape.Raygun4Net
       private readonly Action<WeakExceptionHandler> _onReferenceDestroyed;
       private readonly WeakReference<UnhandledExceptionHandler> _reference;
 
+      public bool IsAlive => _reference.TryGetTarget(out _);
+
       public WeakExceptionHandler(UnhandledExceptionHandler handler, Action<WeakExceptionHandler> onReferenceDestroyed)
       {
         _onReferenceDestroyed = onReferenceDestroyed;
         _reference = new WeakReference<UnhandledExceptionHandler>(handler);
       }
 
-      public void Handle(Exception exception, bool isTerminating)
+      public void Invoke(Exception exception, bool isTerminating)
       {
         // If the target is still alive then forward the invocation
         if (_reference.TryGetTarget(out var handle))


### PR DESCRIPTION
Effectively manage the lifecycle of handlers

This change should be released under 8.2.1

Further fixes #508 and extends on #509