### PR TITLE
Fix Lock recursion 

### DIFF
--- a/Mindscape.Raygun4Net.NetCore.Common/UnhandledExceptionBridge.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/UnhandledExceptionBridge.cs
@@ -13,8 +13,7 @@ namespace Mindscape.Raygun4Net
 
     private static readonly List<WeakExceptionHandler> Handlers = new List<WeakExceptionHandler>();
 
-    private static readonly ReaderWriterLockSlim HandlersLock =
-      new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+    private static readonly ReaderWriterLockSlim HandlersLock = new ReaderWriterLockSlim();
 
     static UnhandledExceptionBridge()
     {
@@ -53,42 +52,18 @@ namespace Mindscape.Raygun4Net
       // Wrap the callback in a weak reference container
       // Then subscribe to the event using the weak reference
       // The onDestroyed function is called - and unregisters it from the multicast delegate
-      var weakHandler = new WeakExceptionHandler(callback, RemoveDeadHandler);
+      var weakHandler = new WeakExceptionHandler(callback);
 
       HandlersLock.EnterWriteLock();
       try
       {
         Handlers.Add(weakHandler);
-        RemoveDeadHandlers();
-      }
-      finally
-      {
-        HandlersLock.ExitWriteLock();
-      }
-    }
-
-    private static void RemoveDeadHandler(WeakExceptionHandler handler)
-    {
-      HandlersLock.EnterWriteLock();
-      try
-      {
-        Handlers.Remove(handler);
-      }
-      finally
-      {
-        HandlersLock.ExitWriteLock();
-      }
-    }
-
-    private static void RemoveDeadHandlers()
-    {
-      HandlersLock.EnterWriteLock();
-      try
-      {
+        
+        // Remove any dead handlers
         var handlersToRemove = Handlers.Where(x => !x.IsAlive).ToList();
         foreach (var handler in handlersToRemove)
         {
-          RemoveDeadHandler(handler);
+          Handlers.Remove(handler);
         }
       }
       finally
@@ -99,28 +74,24 @@ namespace Mindscape.Raygun4Net
 
     private class WeakExceptionHandler
     {
-      private readonly Action<WeakExceptionHandler> _onReferenceDestroyed;
       private readonly WeakReference<UnhandledExceptionHandler> _reference;
 
       public bool IsAlive => _reference.TryGetTarget(out _);
 
-      public WeakExceptionHandler(UnhandledExceptionHandler handler, Action<WeakExceptionHandler> onReferenceDestroyed)
+      public WeakExceptionHandler(UnhandledExceptionHandler handler)
       {
-        _onReferenceDestroyed = onReferenceDestroyed;
         _reference = new WeakReference<UnhandledExceptionHandler>(handler);
       }
 
       public void Invoke(Exception exception, bool isTerminating)
       {
-        // If the target is still alive then forward the invocation
-        if (_reference.TryGetTarget(out var handle))
+        // If the target is dead then do nothing
+        if (!_reference.TryGetTarget(out var handle))
         {
-          handle.Invoke(exception, isTerminating);
           return;
         }
-
-        // the reference is dead, so call the clean up function
-        _onReferenceDestroyed(this);
+        
+        handle.Invoke(exception, isTerminating);
       }
     }
   }

--- a/Mindscape.Raygun4Net.NetCore.Common/UnhandledExceptionBridge.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/UnhandledExceptionBridge.cs
@@ -51,7 +51,6 @@ namespace Mindscape.Raygun4Net
     {
       // Wrap the callback in a weak reference container
       // Then subscribe to the event using the weak reference
-      // The onDestroyed function is called - and unregisters it from the multicast delegate
       var weakHandler = new WeakExceptionHandler(callback);
 
       HandlersLock.EnterWriteLock();
@@ -59,7 +58,7 @@ namespace Mindscape.Raygun4Net
       {
         Handlers.Add(weakHandler);
         
-        // Remove any dead handlers
+        // Remove any handlers where their references are no longer alive
         var handlersToRemove = Handlers.Where(x => !x.IsAlive).ToList();
         foreach (var handler in handlersToRemove)
         {

--- a/Mindscape.Raygun4Net.NetCore.Tests/UnhandledExceptionBridgeTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/UnhandledExceptionBridgeTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Mindscape.Raygun4Net.NetCore.Tests
@@ -20,6 +18,8 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
         UnhandledExceptionBridge.OnUnhandledException(Callback);
         UnhandledExceptionBridge.OnUnhandledException(Callback);
 
+        return;
+        
         void Callback(Exception e, bool b)
         {
         }
@@ -32,7 +32,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
       
       try
       {
-        // Manually for an unhandled exception, to handlers that are not alive
+        // Manually raise an unhandled exception, to handlers that are not alive
         // Which should cause the lock upgrade exception
         UnhandledExceptionBridge.RaiseUnhandledException(new Exception("Dead"), false);
       }

--- a/Mindscape.Raygun4Net.NetCore.Tests/UnhandledExceptionBridgeTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/UnhandledExceptionBridgeTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Mindscape.Raygun4Net.NetCore.Tests
+{
+  [TestFixture]
+  public class UnhandledExceptionBridgeTests
+  {
+    [Test]
+    public void UnhandledExceptionBridge_WhenHandlersAreNoLongerAlive_LockExceptionsAreNotThrown()
+    {
+      Exception observedException = null;
+
+      // Need to put this into an action to cause the references to be destroyed on the GC
+      new Action(() =>
+      {
+        UnhandledExceptionBridge.OnUnhandledException(Callback);
+        UnhandledExceptionBridge.OnUnhandledException(Callback);
+        UnhandledExceptionBridge.OnUnhandledException(Callback);
+
+        void Callback(Exception e, bool b)
+        {
+        }
+      })();
+
+      // GC the callbacks, causing their handlers to be marked as not alive
+      GC.Collect();
+      GC.WaitForPendingFinalizers();
+      GC.Collect();
+      
+      try
+      {
+        // Manually for an unhandled exception, to handlers that are not alive
+        // Which should cause the lock upgrade exception
+        UnhandledExceptionBridge.RaiseUnhandledException(new Exception("Dead"), false);
+      }
+      catch (Exception ex)
+      {
+        observedException = ex;
+      }
+      
+      Assert.That(observedException, Is.Null);
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.NetCore.Tests/UnhandledExceptionBridgeTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/UnhandledExceptionBridgeTests.cs
@@ -6,6 +6,10 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
   [TestFixture]
   public class UnhandledExceptionBridgeTests
   {
+    /// <summary>
+    /// GitHub Issue: 513
+    /// See https://github.com/MindscapeHQ/raygun4net/issues/513 for the issue report
+    /// </summary>
     [Test]
     public void UnhandledExceptionBridge_WhenHandlersAreNoLongerAlive_LockExceptionsAreNotThrown()
     {
@@ -32,8 +36,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
       
       try
       {
-        // Manually raise an unhandled exception, to handlers that are not alive
-        // Which should cause the lock upgrade exception
+        // Manually raise an exception, to handlers references that are no longer alive.
         UnhandledExceptionBridge.RaiseUnhandledException(new Exception("Dead"), false);
       }
       catch (Exception ex)


### PR DESCRIPTION
This addresses the Lock Recursion exception raised in #513 

Don't try to clean up the handlers in the invocation.

Instead move all the logic to the add method.

This is slightly less optimal on the memory, but makes managing the locks across threads much simpler and less error prone.


The test was created and was able to reproduce the issue in 9.0.0, the "broken" test now passes.