### PR TITLE
Remove the usage of LocalThread in .NET Framework versions

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,9 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v9.0.2
+- Remove the usage of `ThreadLocal` in the RaygunClient (for .NET Framework)
+  - This does not affect the NetCore version 
+
 ### v9.0.1
 - Fixed issue for lock upgrade/recursion exception raised
   - https://github.com/MindscapeHQ/raygun4net/issues/513

--- a/Mindscape.Raygun4Net.WebApi/Builders/RaygunWebApiRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/Builders/RaygunWebApiRequestMessageBuilder.cs
@@ -19,7 +19,7 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
     {
       options = options ?? new RaygunRequestMessageOptions();
 
-      var message = new RaygunRequestMessage()
+      var message = new RaygunRequestMessage
       {
         IPAddress   = GetIPAddress(request),
         QueryString = GetQueryString(request, options),

--- a/Mindscape.Raygun4Net.WebApi/Filters/RaygunWebApiActionFilter.cs
+++ b/Mindscape.Raygun4Net.WebApi/Filters/RaygunWebApiActionFilter.cs
@@ -19,11 +19,9 @@ namespace Mindscape.Raygun4Net.WebApi
       // Don't bother processing bad StatusCodes if there is an exception attached - it will be handled by another part of the framework.
       if (context != null && context.Exception == null && context.Response != null && (int)context.Response.StatusCode >= 400)
       {
-        var e = new RaygunWebApiHttpException(
-          $"HTTP {(int)context.Response.StatusCode} returned while handling Request {context.Request.Method} {context.Request.RequestUri}",
-          context.Response);
+        var e = new RaygunWebApiHttpException($"HTTP {(int)context.Response.StatusCode} returned while handling Request {context.Request.Method} {context.Request.RequestUri}", context.Response);
 
-        _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(e, new List<string> {RaygunWebApiClient.UnhandledExceptionTag});
+        _clientCreator.GenerateRaygunWebApiClient().SendInBackground(e, new List<string> {RaygunWebApiClient.UnhandledExceptionTag});
       }
     }
   }

--- a/Mindscape.Raygun4Net.WebApi/Filters/RaygunWebApiExceptionFilter.cs
+++ b/Mindscape.Raygun4Net.WebApi/Filters/RaygunWebApiExceptionFilter.cs
@@ -16,13 +16,13 @@ namespace Mindscape.Raygun4Net.WebApi
 
     public override void OnException(HttpActionExecutedContext context)
     {
-      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
+      _clientCreator.GenerateRaygunWebApiClient().SendInBackground(context.Exception, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
     }
 
 #pragma warning disable 1998
     public override async Task OnExceptionAsync(HttpActionExecutedContext context, CancellationToken cancellationToken)
     {
-      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
+      _clientCreator.GenerateRaygunWebApiClient().SendInBackground(context.Exception, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
     }
 #pragma warning restore 1998
   }

--- a/Mindscape.Raygun4Net.WebApi/IRaygunWebApiClientProvider.cs
+++ b/Mindscape.Raygun4Net.WebApi/IRaygunWebApiClientProvider.cs
@@ -1,9 +1,7 @@
-﻿using System.Net.Http;
-
-namespace Mindscape.Raygun4Net.WebApi
+﻿namespace Mindscape.Raygun4Net.WebApi
 {
   internal interface IRaygunWebApiClientProvider
   {
-    RaygunWebApiClient GenerateRaygunWebApiClient(HttpRequestMessage currentRequest = null);
+    RaygunWebApiClient GenerateRaygunWebApiClient();
   }
 }

--- a/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
+++ b/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
@@ -30,6 +30,7 @@
   
   <ItemGroup>
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
+++ b/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
@@ -50,4 +50,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Mindscape.Raygun4Net.Core\Mindscape.Raygun4Net.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <InternalsVisibleTo Include="Mindscape.Raygun4Net.WebApi.Tests"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <InternalsVisibleTo Include="Mindscape.Raygun4Net.WebApi.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100499b604a09b4538bcd0e626ae13f86083c9ab5950e3d7f8465d18fb93fd5e445b8fa2a46c42187b02aaeea0b8f738f238b9e1975384adf036cca1545619980c3fbfaf0fe47b9b9e88986f02cdbdeea9d69876e4fbba06b1a9dfc79eb829e258a12d1e751042384655719e3dd58552c18a978f953d110ea0209535682d64ec5bf"/>
+  </ItemGroup>
 </Project>

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Dispatcher;
@@ -599,7 +598,7 @@ namespace Mindscape.Raygun4Net.WebApi
 
     private static HttpRequestMessage ConvertHttpContext(HttpContext httpContext)
     {
-      return httpContext.Items["MS_HttpRequestMessage"] as HttpRequestMessage;
+      return httpContext?.Items["MS_HttpRequestMessage"] as HttpRequestMessage;
     }
 
     protected RaygunMessage BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData)

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClientProvider.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClientProvider.cs
@@ -5,18 +5,16 @@ namespace Mindscape.Raygun4Net.WebApi
 {
   internal class RaygunWebApiClientProvider : IRaygunWebApiClientProvider
   {
-    private readonly Func<HttpRequestMessage, RaygunWebApiClient> _generateRaygunClient;
+    private readonly Func<RaygunWebApiClient> _generateRaygunClient;
     private readonly string _applicationVersionFromAttach;
 
-    public RaygunWebApiClientProvider(
-      Func<HttpRequestMessage, RaygunWebApiClient> generateRaygunClientWithHttpRequest,
-      string applicationVersionFromAttach)
+    public RaygunWebApiClientProvider(Func<RaygunWebApiClient> generateRaygunClientWithHttpRequest, string applicationVersionFromAttach)
     {
       _generateRaygunClient = generateRaygunClientWithHttpRequest;
       _applicationVersionFromAttach = applicationVersionFromAttach;
     }
 
-    public RaygunWebApiClient GenerateRaygunWebApiClient(HttpRequestMessage currentRequest = null)
+    public RaygunWebApiClient GenerateRaygunWebApiClient()
     {
       RaygunWebApiClient client = null;
 
@@ -27,10 +25,8 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       else
       {
-        client = _generateRaygunClient(currentRequest);
+        client = _generateRaygunClient();
       }
-      
-      client?.SetCurrentHttpRequest(currentRequest);
       
       return client;
     }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiMessageBuilder.cs
@@ -170,5 +170,11 @@ namespace Mindscape.Raygun4Net.WebApi
 
       return this;
     }
+
+    public IRaygunMessageBuilder Customise(Action<IRaygunMessageBuilder> customiseAction)
+    {
+      customiseAction?.Invoke(this);
+      return this;
+    }
   }
 }

--- a/Mindscape.Raygun4Net.WebApi/Selectors/RaygunWebApiActionSelector.cs
+++ b/Mindscape.Raygun4Net.WebApi/Selectors/RaygunWebApiActionSelector.cs
@@ -23,7 +23,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch (HttpResponseException ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient(controllerContext.Request).SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
+        _clientCreator.GenerateRaygunWebApiClient().SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
         throw;
       }
     }

--- a/Mindscape.Raygun4Net.WebApi/Selectors/RaygunWebApiControllerSelector.cs
+++ b/Mindscape.Raygun4Net.WebApi/Selectors/RaygunWebApiControllerSelector.cs
@@ -25,7 +25,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch (HttpResponseException ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
+        _clientCreator.GenerateRaygunWebApiClient().SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
         throw;
       }
     }

--- a/Mindscape.Raygun4Net.WebApi/Services/RaygunWebApiControllerActivator.cs
+++ b/Mindscape.Raygun4Net.WebApi/Services/RaygunWebApiControllerActivator.cs
@@ -25,14 +25,14 @@ namespace Mindscape.Raygun4Net.WebApi
       }
       catch(InvalidOperationException ex)
       {
-        var client = _clientCreator.GenerateRaygunWebApiClient(request);
+        var client = _clientCreator.GenerateRaygunWebApiClient();
         client.SendInBackground(ex.InnerException, new List<string> {RaygunWebApiClient.UnhandledExceptionTag});
         client.FlagExceptionAsSent(ex); // Stops us re-sending the outer exception
         throw;
       }
       catch(Exception ex)
       {
-        _clientCreator.GenerateRaygunWebApiClient(request).SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
+        _clientCreator.GenerateRaygunWebApiClient().SendInBackground(ex, new List<string> { RaygunWebApiClient.UnhandledExceptionTag });
         throw;
       }
     }

--- a/Mindscape.Raygun4Net.WebApi/Services/RaygunWebApiExceptionLogger.cs
+++ b/Mindscape.Raygun4Net.WebApi/Services/RaygunWebApiExceptionLogger.cs
@@ -15,13 +15,13 @@ namespace Mindscape.Raygun4Net.WebApi
 
     public override void Log(ExceptionLoggerContext context)
     {
-      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient().SendInBackground(context.Exception);
     }
 
 #pragma warning disable 1998
     public override async Task LogAsync(ExceptionLoggerContext context, CancellationToken cancellationToken)
     {
-      _clientCreator.GenerateRaygunWebApiClient(context.Request).SendInBackground(context.Exception);
+      _clientCreator.GenerateRaygunWebApiClient().SendInBackground(context.Exception);
     }
 #pragma warning restore 1998
   }


### PR DESCRIPTION
Sometimes a null-ref exception occurs when building the message due to the fields being persistent in the RaygunClient when using SendInBackground. 

This PR makes the data scoped to the function and passed through.

Also cleaned up some methods now that the version of C# has been updated, we can use optional parameters. 