### PR TITLE
Fix NRE when calling SendInBackground

### DIFF
--- a/Mindscape.Raygun4Net.Core/IRaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.Core/IRaygunMessageBuilder.cs
@@ -28,5 +28,7 @@ namespace Mindscape.Raygun4Net
     IRaygunMessageBuilder SetTimeStamp(DateTime? currentTime);
 
     IRaygunMessageBuilder SetContextId(string contextId);
+
+    IRaygunMessageBuilder Customise(Action<IRaygunMessageBuilder> customiseAction);
   }
 }

--- a/Mindscape.Raygun4Net.Core/Messages/RaygunMessage.cs
+++ b/Mindscape.Raygun4Net.Core/Messages/RaygunMessage.cs
@@ -1,24 +1,17 @@
 ﻿using System;
 
-namespace Mindscape.Raygun4Net.Messages
+namespace Mindscape.Raygun4Net.Messages;
+
+public class RaygunMessage
 {
-  public class RaygunMessage
+  public DateTime OccurredOn { get; set; } = DateTime.UtcNow;
+
+  public RaygunMessageDetails Details { get; set; } = new();
+
+  public override string ToString()
   {
-    public RaygunMessage()
-    {
-      OccurredOn = DateTime.UtcNow;
-      Details = new RaygunMessageDetails();
-    }
-
-    public DateTime OccurredOn { get; set; }
-
-    public RaygunMessageDetails Details { get; set; }
-
-    public override string ToString()
-    {
-      // This exists because Reflection in Xamarin can't seem to obtain the Getter methods unless the getter is used somewhere in the code.
-      // The getter of all properties is required to serialize the Raygun messages to JSON.
-      return string.Format("[RaygunMessage: OccurredOn={0}, Details={1}]", OccurredOn, Details);
-    }
+    // This exists because Reflection in Xamarin can't seem to obtain the Getter methods unless the getter is used somewhere in the code.
+    // The getter of all properties is required to serialize the Raygun messages to JSON.
+    return $"[RaygunMessage: OccurredOn={OccurredOn}, Details={Details}]";
   }
 }

--- a/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunMessage.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunMessage.cs
@@ -4,16 +4,10 @@ namespace Mindscape.Raygun4Net
 {
   public class RaygunMessage
   {
-    public RaygunMessage()
-    {
-      OccurredOn = DateTime.UtcNow;
-      Details = new RaygunMessageDetails();
-    }
-    
-    public DateTime OccurredOn { get; set; }
+    public DateTime OccurredOn { get; set; } = DateTime.UtcNow;
 
-    public RaygunMessageDetails Details { get; set; }
-    
+    public RaygunMessageDetails Details { get; set; } = new();
+
     public override string ToString()
     {
       // This exists because Reflection in Xamarin can't seem to obtain the Getter methods unless the getter is used somewhere in the code.

--- a/Mindscape.Raygun4Net4/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net4/RaygunMessageBuilder.cs
@@ -223,5 +223,11 @@ namespace Mindscape.Raygun4Net
 
       return this;
     }
+    
+    public IRaygunMessageBuilder Customise(Action<IRaygunMessageBuilder> customiseAction)
+    {
+      customiseAction?.Invoke(this);
+      return this;
+    }
   }
 }

--- a/Raygun.CrashReporting.sln.DotSettings
+++ b/Raygun.CrashReporting.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mindscape/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
When the `RaygunWebApiClient` is created using the empty ctor, it does not new up the background processor and this causes an exception to be thrown when `SendInBackground` is called.

```
System.NullReferenceException : Object reference not set to an instance of an object.
   at Mindscape.Raygun4Net.WebApi.RaygunWebApiClient.StripAndSendInBackground(Exception exception, IList`1 tags, IDictionary userCustomData, Nullable`1 currentTime, Action`1 customiseAction) in C:\Codez\raygun4net\Mindscape.Raygun4Net.WebApi\RaygunWebApiClient.cs:line 588
   at Mindscape.Raygun4Net.WebApi.RaygunWebApiClient.SendInBackground(Exception exception, IList`1 tags, IDictionary userCustomData) in C:\Codez\raygun4net\Mindscape.Raygun4Net.WebApi\RaygunWebApiClient.cs:line 474
```