### PR TITLE
Added support for capturing Environment Variables

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,11 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v10.1.0
+- Add support for capturing Environment Variables in NetCore
+  - New setting `EnvironmentVariables` which takes a list of search terms
+  - Supports Exact, StartsWith, EndsWith, and Contains matching
+  - See: 
+
 ### v10.0.0
 - RaygunClient for NET Core can now be treated as a Singleton
 - Changed the Middleware for AspNetCore

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -4,7 +4,7 @@
 - Add support for capturing Environment Variables in NetCore
   - New setting `EnvironmentVariables` which takes a list of search terms
   - Supports Exact, StartsWith, EndsWith, and Contains matching
-  - See: 
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/523
 
 ### v10.0.0
 - RaygunClient for NET Core can now be treated as a Singleton

--- a/Mindscape.Raygun4Net.AspNetCore.Tests/Program.cs
+++ b/Mindscape.Raygun4Net.AspNetCore.Tests/Program.cs
@@ -9,7 +9,11 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 builder.Services.AddMvc();
-builder.Services.AddRaygun(builder.Configuration);
+builder.Services.AddRaygun(builder.Configuration, settings =>
+{
+  settings.EnvironmentVariables.Add("USER_*");
+  settings.EnvironmentVariables.Add("POSH_*");
+});
 
 // because we're using a library that uses Raygun, we need to initialize that too
 RaygunClientFactory.Initialize(builder.Configuration["RaygunSettings:ApiKey"]);

--- a/Mindscape.Raygun4Net.AspNetCore.Tests/Program.cs
+++ b/Mindscape.Raygun4Net.AspNetCore.Tests/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddMvc();
 builder.Services.AddRaygun(builder.Configuration, settings =>
 {
-  settings.EnvironmentVariables.Add("USER_*");
+  settings.EnvironmentVariables.Add("USER*");
   settings.EnvironmentVariables.Add("POSH_*");
 });
 

--- a/Mindscape.Raygun4Net.NetCore.Common/Builders/EnvironmentProviders/EnvironmentVariablesProvider.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Builders/EnvironmentProviders/EnvironmentVariablesProvider.cs
@@ -3,6 +3,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Mindscape.Raygun4Net.EnvironmentProviders;
 
@@ -20,6 +21,11 @@ public class EnvironmentVariablesProvider
 
     foreach (var search in settings.EnvironmentVariables!)
     {
+      if (Regex.IsMatch(search, "^[*]+$", RegexOptions.Compiled))
+      {
+        continue;
+      }
+      
       var values = search switch
       {
         _ when search.StartsWith("*") && search.EndsWith("*") => GetContainsVariable(environmentVariables, search.Trim('*')),

--- a/Mindscape.Raygun4Net.NetCore.Common/Builders/EnvironmentProviders/EnvironmentVariablesProvider.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Builders/EnvironmentProviders/EnvironmentVariablesProvider.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +18,7 @@ public class EnvironmentVariablesProvider
     }
 
     var result = new Dictionary<string, string>();
-    var environmentVariables = System.Environment.GetEnvironmentVariables();
+    var environmentVariables = Environment.GetEnvironmentVariables();
 
     foreach (var search in settings.EnvironmentVariables!)
     {
@@ -49,27 +50,34 @@ public class EnvironmentVariablesProvider
 
   private static IEnumerable<(string, string?)> GetContainsVariable(IDictionary environmentVariables, string search)
   {
-    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.Contains(search));
+    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0);
     
     return matchingKeys.Select(key => (key, environmentVariables[key]?.ToString()));
   }
 
   private static IEnumerable<(string, string?)> GetEndsWithVariable(IDictionary environmentVariables, string search)
   {
-    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.EndsWith(search));
+    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.EndsWith(search, StringComparison.OrdinalIgnoreCase));
     
     return matchingKeys.Select(key => (key, environmentVariables[key]?.ToString()));
   }
 
   private static IEnumerable<(string, string?)> GetStartsWithVariable(IDictionary environmentVariables, string search)
   {
-    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.StartsWith(search));
+    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.StartsWith(search, StringComparison.OrdinalIgnoreCase));
     
     return matchingKeys.Select(key => (key, environmentVariables[key]?.ToString()));
   }
 
   private static IEnumerable<(string, string?)> GetExactVariable(IDictionary environmentVariables, string search)
   {
-    yield return (search, environmentVariables[search]?.ToString());
+    var matchingKey = environmentVariables.Keys.Cast<string>().FirstOrDefault(key => key.Equals(search, StringComparison.OrdinalIgnoreCase));
+    
+    if (matchingKey == null)
+    {
+      yield break;
+    }
+    
+    yield return (matchingKey, environmentVariables[matchingKey]?.ToString());
   }
 }

--- a/Mindscape.Raygun4Net.NetCore.Common/Builders/EnvironmentProviders/EnvironmentVariablesProvider.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Builders/EnvironmentProviders/EnvironmentVariablesProvider.cs
@@ -1,0 +1,69 @@
+﻿#nullable enable
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mindscape.Raygun4Net.EnvironmentProviders;
+
+public class EnvironmentVariablesProvider
+{
+  public static IDictionary? GetEnvironmentVariables(RaygunSettingsBase settings)
+  {
+    if (settings.EnvironmentVariables == null || settings.EnvironmentVariables?.Count == 0)
+    {
+      return null;
+    }
+
+    var result = new Dictionary<string, string>();
+    var environmentVariables = System.Environment.GetEnvironmentVariables();
+
+    foreach (var search in settings.EnvironmentVariables!)
+    {
+      var values = search switch
+      {
+        _ when search.StartsWith("*") && search.EndsWith("*") => GetContainsVariable(environmentVariables, search.Trim('*')),
+        _ when search.StartsWith("*") => GetEndsWithVariable(environmentVariables, search.Trim('*')),
+        _ when search.EndsWith("*") => GetStartsWithVariable(environmentVariables, search.Trim('*')),
+        _ => GetExactVariable(environmentVariables, search)
+      };
+
+      foreach (var (key, value) in values)
+      {
+        // If adding failed we probably already added it from a previous search
+        if (!result.ContainsKey(key))
+        {
+          result.Add(key, value ?? string.Empty);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private static IEnumerable<(string, string?)> GetContainsVariable(IDictionary environmentVariables, string search)
+  {
+    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.Contains(search));
+    
+    return matchingKeys.Select(key => (key, environmentVariables[key]?.ToString()));
+  }
+
+  private static IEnumerable<(string, string?)> GetEndsWithVariable(IDictionary environmentVariables, string search)
+  {
+    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.EndsWith(search));
+    
+    return matchingKeys.Select(key => (key, environmentVariables[key]?.ToString()));
+  }
+
+  private static IEnumerable<(string, string?)> GetStartsWithVariable(IDictionary environmentVariables, string search)
+  {
+    var matchingKeys = environmentVariables.Keys.Cast<string>().Where(key => key.StartsWith(search));
+    
+    return matchingKeys.Select(key => (key, environmentVariables[key]?.ToString()));
+  }
+
+  private static IEnumerable<(string, string?)> GetExactVariable(IDictionary environmentVariables, string search)
+  {
+    yield return (search, environmentVariables[search]?.ToString());
+  }
+}

--- a/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunEnvironmentMessage.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Messages/RaygunEnvironmentMessage.cs
@@ -1,33 +1,35 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 
-namespace Mindscape.Raygun4Net
+namespace Mindscape.Raygun4Net;
+
+public class RaygunEnvironmentMessage
 {
-  public class RaygunEnvironmentMessage
-  {
-    public int ProcessorCount { get; set; }
+  public int ProcessorCount { get; set; }
 
-    public string OSVersion { get; set; }
+  public string OSVersion { get; set; }
 
-    public double WindowBoundsWidth { get; set; }
+  public double WindowBoundsWidth { get; set; }
 
-    public double WindowBoundsHeight { get; set; }
+  public double WindowBoundsHeight { get; set; }
 
-    public string Cpu { get; set; }
+  public string Cpu { get; set; }
 
-    public string Architecture { get; set; }
+  public string Architecture { get; set; }
 
-    public ulong TotalVirtualMemory { get; set; }
+  public ulong TotalVirtualMemory { get; set; }
 
-    public ulong AvailableVirtualMemory { get; set; }
+  public ulong AvailableVirtualMemory { get; set; }
 
-    public List<double> DiskSpaceFree { get; set; }
+  public List<double> DiskSpaceFree { get; set; }
 
-    public ulong TotalPhysicalMemory { get; set; }
+  public ulong TotalPhysicalMemory { get; set; }
 
-    public ulong AvailablePhysicalMemory { get; set; }
+  public ulong AvailablePhysicalMemory { get; set; }
 
-    public double UtcOffset { get; set; }
+  public double UtcOffset { get; set; }
 
-    public string Locale { get; set; }
-  }
+  public string Locale { get; set; }
+    
+  public IDictionary EnvironmentVariables { get; set; }
 }

--- a/Mindscape.Raygun4Net.NetCore.Common/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/RaygunSettings.cs
@@ -1,54 +1,65 @@
 ﻿using System;
+using System.Collections.Generic;
 
-namespace Mindscape.Raygun4Net
+namespace Mindscape.Raygun4Net;
+
+public abstract class RaygunSettingsBase
 {
-  public abstract class RaygunSettingsBase
+  private const string DefaultApiEndPoint = "https://api.raygun.com/entries";
+  private const string RaygunMessageQueueMaxVariable = "RAYGUN_MESSAGE_QUEUE_MAX";
+
+  // ReSharper disable once PublicConstructorInAbstractClass
+  public RaygunSettingsBase()
   {
-    private const string DefaultApiEndPoint = "https://api.raygun.com/entries";
-    private const string RaygunMessageQueueMaxVariable = "RAYGUN_MESSAGE_QUEUE_MAX";
-
-    public RaygunSettingsBase()
+    // See if there's an overload defined in an environment variable, and set it accordingly
+    var messageQueueMaxValue = Environment.GetEnvironmentVariable(RaygunMessageQueueMaxVariable);
+    if (!string.IsNullOrEmpty(messageQueueMaxValue) && int.TryParse(messageQueueMaxValue, out var maxQueueSize))
     {
-      ApiEndpoint = new Uri(DefaultApiEndPoint);
-      
-      // See if there's an overload defined in an environment variable, and set it accordingly
-      var messageQueueMaxValue = Environment.GetEnvironmentVariable(RaygunMessageQueueMaxVariable);
-      if (!string.IsNullOrEmpty(messageQueueMaxValue) && int.TryParse(messageQueueMaxValue, out var maxQueueSize))
-      {
-        BackgroundMessageQueueMax = maxQueueSize;
-      }
+      BackgroundMessageQueueMax = maxQueueSize;
     }
-
-    /// <summary>
-    /// Raygun Application API Key, can be found in the Raygun application dashboard by clicking the "Application settings" button
-    /// </summary>
-    public string ApiKey { get; set; }
- 
-    public Uri ApiEndpoint { get; set; }
-
-    public bool ThrowOnError { get; set; }
-
-    public string ApplicationVersion { get; set; }
-
-    /// <summary>
-    /// If set to true will automatically setup handlers to catch Unhandled Exceptions
-    /// </summary>
-    /// <remarks>
-    /// Currently defaults to false. This may be change in future releases.
-    /// </remarks>
-    public bool CatchUnhandledExceptions { get; set; } = false;
-
-    /// <summary>
-    /// The maximum queue size for background exceptions
-    /// </summary>
-    public int BackgroundMessageQueueMax { get; } = ushort.MaxValue;
-
-    /// <summary>
-    /// Controls the number of background threads used to process the raygun message queue
-    /// </summary>
-    /// <remarks>
-    /// Defaults to Environment.ProcessorCount * 2 &gt;= 8 ? 8 : Environment.ProcessorCount * 2
-    /// </remarks>
-    public int BackgroundMessageWorkerCount { get; set; } = Environment.ProcessorCount * 2 >= 8 ? 8 : Environment.ProcessorCount * 2;
   }
+
+  /// <summary>
+  /// Raygun Application API Key, can be found in the Raygun application dashboard by clicking the "Application settings" button
+  /// </summary>
+  public string ApiKey { get; set; }
+ 
+  public Uri ApiEndpoint { get; set; } = new (DefaultApiEndPoint);
+
+  public bool ThrowOnError { get; set; }
+
+  public string ApplicationVersion { get; set; }
+
+  /// <summary>
+  /// If set to true will automatically setup handlers to catch Unhandled Exceptions
+  /// </summary>
+  /// <remarks>
+  /// Currently defaults to false. This may be change in future releases.
+  /// </remarks>
+  public bool CatchUnhandledExceptions { get; set; } = false;
+
+  /// <summary>
+  /// The maximum queue size for background exceptions
+  /// </summary>
+  public int BackgroundMessageQueueMax { get; } = ushort.MaxValue;
+
+  /// <summary>
+  /// Controls the number of background threads used to process the raygun message queue
+  /// </summary>
+  /// <remarks>
+  /// Defaults to Environment.ProcessorCount * 2 &gt;= 8 ? 8 : Environment.ProcessorCount * 2
+  /// </remarks>
+  public int BackgroundMessageWorkerCount { get; set; } = Environment.ProcessorCount * 2 >= 8 ? 8 : Environment.ProcessorCount * 2;
+
+  /// <summary>
+  /// A list of Environment Variables to include with the message.
+  /// </summary>
+  /// <remarks>
+  /// Can include wildcards to support Exact, StartsWith, EndsWith and Contains matching.
+  /// <br />
+  /// Example: "PATH", "TEM*", "*EM*", "*EMP"
+  /// <br />
+  /// Passing in * will be ignored as we do not want to support collecting 'all' environment variables for security reasons.
+  /// </remarks>
+  public IList<string> EnvironmentVariables { get; set; } = new List<string>();
 }

--- a/Mindscape.Raygun4Net.NetCore.Tests/RaygunBreadcrumbsTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/RaygunBreadcrumbsTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Mindscape.Raygun4Net.Breadcrumbs;
-using NUnit.Framework;
 
 namespace Mindscape.Raygun4Net.NetCore.Tests
 {

--- a/Mindscape.Raygun4Net.NetCore.Tests/RaygunMessageBuilderTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/RaygunMessageBuilderTests.cs
@@ -137,7 +137,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
       
       var msg = builder.Build();
 
-      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>().Should().Contain("PATH");
+      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>().Should().Contain(s => s.Equals("path", StringComparison.OrdinalIgnoreCase));
     }
     
     [Test]
@@ -249,6 +249,37 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
 
       msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>()
          .Should().HaveCount(0);
+    }
+    
+    [TestCase("LEMON", "lemon")]
+    [TestCase("kIwIfRuIt", "KIWIFRUIT")]
+    [TestCase("WAterMeLON", "water*")]
+    [TestCase("gRaPE", "*ape")]
+    [TestCase("DraGonFrUiT", "*nfr*")]
+    public void SetEnvironmentDetails_WithEnvironmentVariablesWithDifferentCasing_ShouldIgnoreCaseAndReturn(string key, string search)
+    {
+      Environment.SetEnvironmentVariable("lOnGan", "1");
+      Environment.SetEnvironmentVariable(key, "2");
+      Environment.SetEnvironmentVariable("aPrIcOt", "3");
+      
+      var settings = new RaygunSettings
+      {
+        EnvironmentVariables = new List<string>
+        {
+          search
+        }
+      };
+      var builder = RaygunMessageBuilder.New(settings)
+                                        .SetEnvironmentDetails();
+      
+      var msg = builder.Build();
+
+      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>()
+         .Should().HaveCount(1)
+         .And.Contain(new []
+         {
+           key
+         });
     }
   }
 }

--- a/Mindscape.Raygun4Net.NetCore.Tests/RaygunMessageBuilderTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/RaygunMessageBuilderTests.cs
@@ -224,5 +224,31 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
         "ONE_Banana_Two"
       });
     }
+    
+    [Test]
+    public void SetEnvironmentDetails_WithEnvironmentVariables_Star_ShouldReturnNothing()
+    {
+      Environment.SetEnvironmentVariable("ONE_Banana_Two", "1");
+      Environment.SetEnvironmentVariable("Two_Test_Three", "2");
+      Environment.SetEnvironmentVariable("ThreeBananaFour", "3");
+      
+      var settings = new RaygunSettings
+      {
+        EnvironmentVariables = new List<string>
+        {
+          "*",
+          "**",
+          "***",
+          "* *",
+        }
+      };
+      var builder = RaygunMessageBuilder.New(settings)
+                                        .SetEnvironmentDetails();
+      
+      var msg = builder.Build();
+
+      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>()
+         .Should().HaveCount(0);
+    }
   }
 }

--- a/Mindscape.Raygun4Net.NetCore.Tests/RaygunMessageBuilderTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/RaygunMessageBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Mindscape.Raygun4Net.NetCore.Tests
@@ -12,6 +13,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     [SetUp]
     public void SetUp()
     {
+      RaygunEnvironmentMessageBuilder.LastUpdate = DateTime.MinValue;
       _settings = new RaygunSettings();
       _builder = RaygunMessageBuilder.New(_settings);
     }
@@ -25,44 +27,41 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     [Test]
     public void SetVersion()
     {
-      IRaygunMessageBuilder builder = _builder.SetVersion("Custom Version");
+      var builder = _builder.SetVersion("Custom Version");
       Assert.That(_builder, Is.EqualTo(builder));
 
-      RaygunMessage message = _builder.Build();
+      var message = _builder.Build();
       Assert.That("Custom Version", Is.EqualTo(message.Details.Version));
     }
 
     [Test]
     public void SetTimeStamp()
     {
-      DateTime time = new DateTime(2015, 2, 16);
-      RaygunMessage message = _builder.SetTimeStamp(time).Build();
+      var time = new DateTime(2015, 2, 16);
+      var message = _builder.SetTimeStamp(time).Build();
       Assert.That(time, Is.EqualTo(message.OccurredOn));
     }
 
     [Test]
     public void SetNullTimeStamp()
     {
-      RaygunMessage message = _builder.SetTimeStamp(null).Build();
+      var message = _builder.SetTimeStamp(null).Build();
       Assert.That((DateTime.UtcNow - message.OccurredOn).TotalSeconds < 1, Is.True);
     }
-
-
 
     [Test]
     public void HasMachineName()
     {
-      RaygunMessage message = _builder.SetMachineName(Environment.MachineName).Build();
+      var message = _builder.SetMachineName(Environment.MachineName).Build();
 
       Assert.That(message.Details, Is.Not.Null);
       Assert.That(message.Details.MachineName, Is.Not.Null);
-
     }
 
     [Test]
     public void HasEnvironmentInformation()
     {
-      RaygunMessage message = _builder.SetEnvironmentDetails().Build();
+      var message = _builder.SetEnvironmentDetails().Build();
 
       Assert.That(message.Details, Is.Not.Null);
       Assert.That(message.Details.Environment, Is.Not.Null);
@@ -85,7 +84,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     [Test]
     public void HasEnvironmentMemoryInformation()
     {
-      RaygunMessage message = _builder.SetEnvironmentDetails().Build();
+      var message = _builder.SetEnvironmentDetails().Build();
 
       Assert.That(message.Details.Environment.AvailablePhysicalMemory, Is.Not.Zero);
       Assert.That(message.Details.Environment.TotalPhysicalMemory, Is.Not.Zero);
@@ -98,9 +97,9 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     [Test]
     public void ResponseIsNullForNonWebExceptions()
     {
-      NullReferenceException exception = new NullReferenceException("The thing is null");
+      var exception = new NullReferenceException("The thing is null");
       _builder.SetExceptionDetails(exception);
-      RaygunMessage message = _builder.Build();
+      var message = _builder.Build();
       Assert.That(message.Details.Response, Is.Null);
     }
     
@@ -121,6 +120,109 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
 
       modifiedMessage.Details.Version.Should().Be("2.0.0");
       modifiedMessage.Details.Environment.Architecture.Should().Be("BANANA");
+    }
+    
+    [Test]
+    public void SetEnvironmentDetails_WithEnvironmentVariables_ExactMatch()
+    {
+      var settings = new RaygunSettings
+      {
+        EnvironmentVariables = new List<string>
+        {
+          "PATH"
+        }
+      };
+      var builder = RaygunMessageBuilder.New(settings)
+                                        .SetEnvironmentDetails();
+      
+      var msg = builder.Build();
+
+      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>().Should().Contain("PATH");
+    }
+    
+    [Test]
+    public void SetEnvironmentDetails_WithEnvironmentVariables_StartsWith()
+    {
+      Environment.SetEnvironmentVariable("TEST_One", "1");
+      Environment.SetEnvironmentVariable("TEST_Two", "2");
+      Environment.SetEnvironmentVariable("TEST_Three", "3");
+      
+      var settings = new RaygunSettings
+      {
+        EnvironmentVariables = new List<string>
+        {
+          "TEST_*"
+        }
+      };
+      var builder = RaygunMessageBuilder.New(settings)
+                                        .SetEnvironmentDetails();
+      
+      var msg = builder.Build();
+
+      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>()
+         .Should().HaveCount(3)
+         .And.Contain(new []
+      {
+        "TEST_One", 
+        "TEST_Two", 
+        "TEST_Three"
+      });
+    }
+    
+    [Test]
+    public void SetEnvironmentDetails_WithEnvironmentVariables_EndsWith()
+    {
+      Environment.SetEnvironmentVariable("One_Banana", "1");
+      Environment.SetEnvironmentVariable("Two_Banana", "2");
+      Environment.SetEnvironmentVariable("Three_Banana", "3");
+      
+      var settings = new RaygunSettings
+      {
+        EnvironmentVariables = new List<string>
+        {
+          "*_Banana"
+        }
+      };
+      var builder = RaygunMessageBuilder.New(settings)
+                                        .SetEnvironmentDetails();
+      
+      var msg = builder.Build();
+
+      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>()
+         .Should().HaveCount(3)
+         .And.Contain(new []
+      {
+        "One_Banana", 
+        "Two_Banana", 
+        "Three_Banana"
+      });
+    }
+    
+    [Test]
+    public void SetEnvironmentDetails_WithEnvironmentVariables_Contains()
+    {
+      Environment.SetEnvironmentVariable("ONE_Banana_Two", "1");
+      Environment.SetEnvironmentVariable("Two_Test_Three", "2");
+      Environment.SetEnvironmentVariable("ThreeBananaFour", "3");
+      
+      var settings = new RaygunSettings
+      {
+        EnvironmentVariables = new List<string>
+        {
+          "*_Banana*"
+        }
+      };
+      var builder = RaygunMessageBuilder.New(settings)
+                                        .SetEnvironmentDetails();
+      
+      var msg = builder.Build();
+
+      msg.Details.Environment.EnvironmentVariables.Keys.Cast<string>()
+         .Should().HaveCount(1)
+         .And.Contain(new []
+      {
+        "ONE_Banana_Two"
+      });
     }
   }
 }


### PR DESCRIPTION
New settings to enable capturing environment variables. 

```csharp
builder.Services.AddRaygun(builder.Configuration, settings =>
{
  settings.EnvironmentVariables.Add("USER*");
  settings.EnvironmentVariables.Add("POSH_*");
});
```

Can do:
- Exact Match: `PATH`
- Starts With: `POSH_*`
- Ends With: `*_VALUE`
- Contains: `*_banana_*`

If you enter `*` only it will return nothing as we don't want to capture everything, variables should be opt-in and explicit, not capture everything and potentially leak sensitive data by mistake. 

![image](https://github.com/MindscapeHQ/raygun4net/assets/895629/39b9be1d-7908-4987-8831-e300de346764)
