### PR TITLE
Reduce overhead from using RaygunBreadcrumb by lazy allocation of CustomData

### DIFF
--- a/Mindscape.Raygun4Net.Core/Breadcrumbs/RaygunBreadcrumb.cs
+++ b/Mindscape.Raygun4Net.Core/Breadcrumbs/RaygunBreadcrumb.cs
@@ -8,9 +8,8 @@ namespace Mindscape.Raygun4Net
   {
     public RaygunBreadcrumb()
     {
-      CustomData = new Dictionary<string, object>();
       Level = RaygunBreadcrumbLevel.Info;
-      Type = RaygunBreadcrumbType.Manual.ToString();
+      Type = nameof(RaygunBreadcrumbType.Manual);
       Timestamp = (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds;
     }
 
@@ -25,7 +24,8 @@ namespace Mindscape.Raygun4Net
     // This is a string due to serialization of enums in SimpleJson to the numeric value.
     public string Type { get; set; }
 
-    public IDictionary<string, object> CustomData { get; set; }
+    public IDictionary<string, object> CustomData { get => _customData ?? (_customData = new Dictionary<string, object>()); set => _customData = value; }
+    private IDictionary<string, object> _customData;
 
     public long Timestamp { get; set; }
 

--- a/Mindscape.Raygun4Net.NetCore.Common/Breadcrumbs/RaygunBreadcrumb.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Breadcrumbs/RaygunBreadcrumb.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Mindscape.Raygun4Net.Breadcrumbs;
 
 namespace Mindscape.Raygun4Net
 {
@@ -15,7 +14,8 @@ namespace Mindscape.Raygun4Net
     // This is a string due to serialization of enums in SimpleJson to the numeric value.
     public string Type { get; set; } = "manual";
 
-    public IDictionary<string, object> CustomData { get; set; } = new Dictionary<string, object>();
+    public IDictionary<string, object> CustomData { get => _customData ?? (_customData = new Dictionary<string, object>()); set => _customData = value; }
+    private IDictionary<string, object> _customData;
 
     public long Timestamp { get; set; } = (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds;
 

--- a/Mindscape.Raygun4Net.NetCore.Common/Breadcrumbs/RaygunBreadcrumbs.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Breadcrumbs/RaygunBreadcrumbs.cs
@@ -21,29 +21,31 @@ namespace Mindscape.Raygun4Net.Breadcrumbs
       Record(new RaygunBreadcrumb { Message = message });
     }
 
-
     public static void Record(RaygunBreadcrumb crumb)
     {
       if (crumb.Message.Length > 500)
       {
         return;
       }
-      
-      try
+
+      if (string.IsNullOrEmpty(crumb.ClassName) || string.IsNullOrEmpty(crumb.MethodName))
       {
-        for (int i = 1; i <= 3; i++)
+        try
         {
-          PopulateLocation(crumb, i);
-          if (crumb.ClassName == null ||
-              !crumb.ClassName.StartsWith("Mindscape.Raygun4Net", StringComparison.OrdinalIgnoreCase))
+          for (int i = 1; i <= 3; i++)
           {
-            break;
+            PopulateLocation(crumb, i);
+            if (crumb.ClassName == null ||
+                !crumb.ClassName.StartsWith("Mindscape.Raygun4Net", StringComparison.OrdinalIgnoreCase))
+            {
+              break;
+            }
           }
         }
-      }
-      catch (Exception)
-      {
-        // ignored
+        catch (Exception)
+        {
+          // ignored
+        }
       }
 
       _storage.Store(crumb);

--- a/Mindscape.Raygun4Net4/Breadcrumbs/HttpBreadcrumbStorage.cs
+++ b/Mindscape.Raygun4Net4/Breadcrumbs/HttpBreadcrumbStorage.cs
@@ -30,22 +30,18 @@ namespace Mindscape.Raygun4Net.Breadcrumbs
 
     private List<RaygunBreadcrumb> GetList()
     {
-      if (HttpContext.Current == null)
+      var httpContext = HttpContext.Current;
+      if (httpContext == null)
       {
         return new List<RaygunBreadcrumb>();
       }
 
-      SetupStorage();
-
-      return (List<RaygunBreadcrumb>) HttpContext.Current.Items[ItemsKey];
-    }
-
-    private void SetupStorage()
-    {
-      if (HttpContext.Current != null && !HttpContext.Current.Items.Contains(ItemsKey))
+      if (!httpContext.Items.Contains(ItemsKey))
       {
-        HttpContext.Current.Items[ItemsKey] = new List<RaygunBreadcrumb>();
+        httpContext.Items[ItemsKey] = new List<RaygunBreadcrumb>();
       }
+
+      return (List<RaygunBreadcrumb>)httpContext.Items[ItemsKey];
     }
   }
 }

--- a/Mindscape.Raygun4Net4/Breadcrumbs/RaygunBreadcrumbs.cs
+++ b/Mindscape.Raygun4Net4/Breadcrumbs/RaygunBreadcrumbs.cs
@@ -27,11 +27,14 @@ namespace Mindscape.Raygun4Net.Breadcrumbs
     
     public void Record(RaygunBreadcrumb crumb)
     {
-      if (RaygunSettings.Settings.BreadcrumbsLocationRecordingEnabled)
+      if (!ShouldRecord(crumb))
+        return;
+
+      if (RaygunSettings.Settings.BreadcrumbsLocationRecordingEnabled && (string.IsNullOrEmpty(crumb.ClassName) || string.IsNullOrEmpty(crumb.MethodName)))
       {
         try
         {
-          for(int i = 1; i <= 3; i++)
+          for (int i = 1; i <= 3; i++)
           {
             PopulateLocation(crumb, i);
             if (crumb.ClassName == null || !crumb.ClassName.StartsWith("Mindscape.Raygun4Net", StringComparison.OrdinalIgnoreCase))
@@ -49,10 +52,7 @@ namespace Mindscape.Raygun4Net.Breadcrumbs
         }
       }
 
-      if (ShouldRecord(crumb))
-      {
-        _storage.Store(crumb);
-      }
+      _storage.Store(crumb);
     }
 
     private void PopulateLocation(RaygunBreadcrumb crumb, int stackTraceFrame)

--- a/Mindscape.Raygun4Net4/Breadcrumbs/RaygunBreadcrumbs.cs
+++ b/Mindscape.Raygun4Net4/Breadcrumbs/RaygunBreadcrumbs.cs
@@ -28,7 +28,9 @@ namespace Mindscape.Raygun4Net.Breadcrumbs
     public void Record(RaygunBreadcrumb crumb)
     {
       if (!ShouldRecord(crumb))
+      {
         return;
+      }
 
       if (RaygunSettings.Settings.BreadcrumbsLocationRecordingEnabled && (string.IsNullOrEmpty(crumb.ClassName) || string.IsNullOrEmpty(crumb.MethodName)))
       {

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -439,7 +439,7 @@ namespace Mindscape.Raygun4Net
     private void StripAndSend(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo, DateTime? currentTime)
     {
       var requestMessage = BuildRequestMessage();
-      var breadcrumbs = _breadcrumbs.ToList();
+      IList<RaygunBreadcrumb> breadcrumbs = BuildBreadCrumbList();
 
       foreach (var e in StripWrapperExceptions(exception))
       {
@@ -450,11 +450,22 @@ namespace Mindscape.Raygun4Net
         }));
       }
     }
-    
+
+    private static IList<RaygunBreadcrumb> BuildBreadCrumbList()
+    {
+      IList<RaygunBreadcrumb> breadCrumbs = null;
+      foreach (var breadCrumb in _breadcrumbs)
+      {
+        breadCrumbs ??= new List<RaygunBreadcrumb>();
+        breadCrumbs.Add(breadCrumb);
+      }
+      return breadCrumbs ?? Array.Empty<RaygunBreadcrumb>();
+    }
+
     private void StripAndSendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo, DateTime? currentTime)
     {
       var requestMessage = BuildRequestMessage();
-      var breadcrumbs = _breadcrumbs.ToList();
+      IList<RaygunBreadcrumb> breadcrumbs = BuildBreadCrumbList();
 
       foreach (var e in StripWrapperExceptions(exception))
       {


### PR DESCRIPTION
Also skip StackTrace probing, when BreadCrumb is prefilled.