### PR TITLE
Fix Issue Where WeakReference Delegate is Garbage Collected While Client is Alive

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,10 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v10.1.2
+- Fix issue where uncaught exceptions could sometimes not be reported to Raygun
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/529
+  - Keeps a strong reference to the `OnApplicationUnhandledException` delegate in the client so that reference is alive as long as the client is
+
 ### v10.1.1
 - Cleanup of the constructors for Net Core RaygunClient
   - See: https://github.com/MindscapeHQ/raygun4net/pull/525

--- a/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
@@ -39,6 +39,13 @@ namespace Mindscape.Raygun4Net
     private readonly ThrottledBackgroundMessageProcessor _backgroundMessageProcessor;
     private readonly IRaygunUserProvider _userProvider;
     protected internal const string SentKey = "AlreadySentByRaygun";
+    
+    /// <summary>
+    /// Store a strong reference to the OnApplicationUnhandledException delegate so it does not get garbage collected while
+    /// the client is still alive
+    /// </summary>
+    private readonly UnhandledExceptionBridge.UnhandledExceptionHandler _onUnhandledExceptionDelegate;
+
 
     /// <summary>
     /// Raised just before a message is sent. This can be used to make final adjustments to the <see cref="RaygunMessage"/>, or to cancel the send.
@@ -116,8 +123,10 @@ namespace Mindscape.Raygun4Net
       _userProvider = userProvider;
 
       _wrapperExceptions.Add(typeof(TargetInvocationException));
-
-      UnhandledExceptionBridge.OnUnhandledException(OnApplicationUnhandledException);
+      
+      _onUnhandledExceptionDelegate = OnApplicationUnhandledException;
+      
+      UnhandledExceptionBridge.OnUnhandledException(_onUnhandledExceptionDelegate);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes an issue where the reference to the delegate that sends unhandled exceptions to the client is garbage collected despite the client being alive. This can cause uncaught exceptions not to be reported to Raygun.

This is fixed by adding a strong reference in the client so that while the client is alive the delegate should be alive too.