### PR TITLE
Add `ConfigureAwait(false)` to the blocking and non blocking Send calls

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,11 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.0.1
+- Raygun4Net.NetCore
+  - Deprecated `RaygunClientBase.Send()`. The asynchronous `SendAsync()` should be preferred in all scenarios to avoid potential deadlocks
+  - Improve the potential deadlocks when calling `Send()` from a UI Thread by adding `ConfigureAwait(false)`
+    - Note: This does not entirely remove the possibility of deadlocks, and `Send()` should not be used within a UI context
+
 ### v11.0.0
 - Add support for PDB Debug Information in stack traces
   - This enables Raygun to leverage Portable PDBs to symbolicate .NET stack traces when PDBs are not included in the build output

--- a/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
@@ -289,6 +289,7 @@ namespace Mindscape.Raygun4Net
     /// Transmits an exception to Raygun synchronously.
     /// </summary>
     /// <param name="exception">The exception to deliver.</param>
+    [Obsolete("Please use SendAsync() to avoid possible deadlocks")]
     public void Send(Exception exception)
     {
       Send(exception, null, null);
@@ -300,6 +301,7 @@ namespace Mindscape.Raygun4Net
     /// </summary>
     /// <param name="exception">The exception to deliver.</param>
     /// <param name="tags">A list of strings associated with the message.</param>
+    [Obsolete("Please use SendAsync() to avoid possible deadlocks")]
     public void Send(Exception exception, IList<string> tags)
     {
       Send(exception, tags, null);
@@ -312,6 +314,7 @@ namespace Mindscape.Raygun4Net
     /// <param name="exception">The exception to deliver.</param>
     /// <param name="tags">A list of strings associated with the message.</param>
     /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
+    [Obsolete("Please use SendAsync() to avoid possible deadlocks")]
     public void Send(Exception exception, IList<string> tags, IDictionary userCustomData)
     {
       try
@@ -335,6 +338,16 @@ namespace Mindscape.Raygun4Net
     public async Task SendAsync(Exception exception)
     {
       await SendAsync(exception, null, null).ConfigureAwait(false);
+    }
+    
+    /// <summary>
+    /// Transmits an exception to Raygun asynchronously.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    public async Task SendAsync(Exception exception, IList<string> tags)
+    {
+      await SendAsync(exception, tags, null).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
@@ -316,7 +316,7 @@ namespace Mindscape.Raygun4Net
     {
       try
       {
-        SendAsync(exception, tags, userCustomData).GetAwaiter().GetResult();
+        SendAsync(exception, tags, userCustomData).ConfigureAwait(false).GetAwaiter().GetResult();
       }
       catch
       {
@@ -332,9 +332,9 @@ namespace Mindscape.Raygun4Net
     /// Transmits an exception to Raygun asynchronously.
     /// </summary>
     /// <param name="exception">The exception to deliver.</param>
-    public Task SendAsync(Exception exception)
+    public async Task SendAsync(Exception exception)
     {
-      return SendAsync(exception, null, null);
+      await SendAsync(exception, null, null).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -505,7 +505,7 @@ namespace Mindscape.Raygun4Net
       try
       {
         var messagePayload = SimpleJson.SerializeObject(raygunMessage);
-        await SendPayloadAsync(messagePayload, _settings.ApiKey, true, cancellationToken);
+        await SendPayloadAsync(messagePayload, _settings.ApiKey, true, cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {
@@ -518,7 +518,7 @@ namespace Mindscape.Raygun4Net
 
     private async Task SendOfflinePayloadAsync(string payload, string apiKey, CancellationToken cancellationToken)
     {
-      await SendPayloadAsync(payload, apiKey, false, cancellationToken);
+      await SendPayloadAsync(payload, apiKey, false, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task SendPayloadAsync(string payload, string apiKey, bool useOfflineStore, CancellationToken cancellationToken)
@@ -561,7 +561,7 @@ namespace Mindscape.Raygun4Net
         return false;
       }
 
-      return await _settings.OfflineStore.Save(messagePayload, apiKey, cancellationToken);
+      return await _settings.OfflineStore.Save(messagePayload, apiKey, cancellationToken).ConfigureAwait(false);
     }
   }
 }


### PR DESCRIPTION
`GetAwaiter().GetResult()` is really not ideal, we have to continue to support the synchronous api, so it's required.

Internally we should be avoiding the usage of Send()


