### PR TITLE
Fix nulls in debug info dictionary

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -11,8 +11,6 @@
     - Note: This does not entirely remove the possibility of deadlocks, and `Send()` should not be used within a UI context
 
 ### v11.0.0
-
-### v11.0.0
 - Add support for PDB Debug Information in stack traces
   - This enables Raygun to leverage Portable PDBs to symbolicate .NET stack traces when PDBs are not included in the build output
   - This introduces a dependency on `System.Reflection.Metadata@6.0.1` for `netstandard`

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,10 +1,16 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.0.2
+- Fix null signature issue when Debug Symbols are set to None and the application is built in Release mode
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/535 
+
 ### v11.0.1
 - Raygun4Net.NetCore
   - Deprecated `RaygunClientBase.Send()`. The asynchronous `SendAsync()` should be preferred in all scenarios to avoid potential deadlocks
   - Improve the potential deadlocks when calling `Send()` from a UI Thread by adding `ConfigureAwait(false)`
     - Note: This does not entirely remove the possibility of deadlocks, and `Send()` should not be used within a UI context
+
+### v11.0.0
 
 ### v11.0.0
 - Add support for PDB Debug Information in stack traces

--- a/Mindscape.Raygun4Net.Core/Builders/RaygunErrorMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.Core/Builders/RaygunErrorMessageBuilder.cs
@@ -175,7 +175,7 @@ namespace Mindscape.Raygun4Net.Builders
         return Enumerable.Empty<PEDebugInformation>();
       }
 
-      var imageMap = DebugInformationCache.Values.Where(x => x != null).ToDictionary(k => k.Signature);
+      var imageMap = DebugInformationCache.Values.Where(x => x?.Signature != null).ToDictionary(k => k.Signature);
       var imageSet = new HashSet<PEDebugInformation>();
 
       foreach (var stackFrame in frames)

--- a/Mindscape.Raygun4Net.NetCore.Common/Builders/RaygunErrorMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Builders/RaygunErrorMessageBuilder.cs
@@ -230,7 +230,7 @@ namespace Mindscape.Raygun4Net
         return Enumerable.Empty<PEDebugInformation>();
       }
       
-      var imageMap = DebugInformationCache.Values.Where(x => x != null).ToDictionary(k => k.Signature);
+      var imageMap = DebugInformationCache.Values.Where(x => x?.Signature != null).ToDictionary(k => k.Signature);
       var imageSet = new HashSet<PEDebugInformation>();
       
       foreach (var stackFrame in frames)


### PR DESCRIPTION
There is a possibility that a frame does not have any debugging information attached to it.

This happens when DebugSymbols is set to "None", and the output is in Release mode. The result is DebugInfo but it does not have a signature or other properties.

This addresses that particular scenario, by null checking the debug info as well as the signature before attempting to create the lookup dictionary.

![image](https://github.com/MindscapeHQ/raygun4net/assets/6000196/977f54f4-7f95-4fd6-8f4b-ed90571059ea)

![image](https://github.com/MindscapeHQ/raygun4net/assets/6000196/6159052f-2e5e-43fe-992f-2d448776871b)


```
System.Exception: Really bad explosion
   at MyCoolClassLibrary.AwesomeClass.ThrowsAnException()
   at Program.<Main>$(String[] args)
Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey](IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
   at Mindscape.Raygun4Net.RaygunErrorMessageBuilder.GetDebugInfoForStackFrames(IEnumerable`1 frames) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\Builders\RaygunErrorMessageBuilder.cs:line 233
   at Mindscape.Raygun4Net.RaygunErrorMessageBuilder.Build(Exception exception) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\Builders\RaygunErrorMessageBuilder.cs:line 204
   at Mindscape.Raygun4Net.RaygunMessageBuilder.SetExceptionDetails(Exception exception) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\Builders\RaygunMessageBuilder.cs:line 54
   at Mindscape.Raygun4Net.RaygunClientBase.BuildMessage(Exception exception, IList`1 tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo, Action`1 customiseMessage) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\RaygunClientBase.cs:line 427
   at Mindscape.Raygun4Net.RaygunClientBase.StripAndSend(Exception exception, IList`1 tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\RaygunClientBase.cs:line 454
   at Mindscape.Raygun4Net.RaygunClientBase.SendAsync(Exception exception, IList`1 tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\RaygunClientBase.cs:line 366
   at Mindscape.Raygun4Net.RaygunClientBase.Send(Exception exception, IList`1 tags, IDictionary userCustomData) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\RaygunClientBase.cs:line 322
   at Mindscape.Raygun4Net.RaygunClientBase.Send(Exception exception) in C:\BuildAgent\work\75116afedfe31196\Mindscape.Raygun4Net.NetCore.Common\RaygunClientBase.cs:line 295
   at Program.<Main>$(String[] args)
   at Program.<Main>(String[] args)
```
