### PR TITLE
Use Singleton RaygunClient in RaygunHttpModule (.NET Framework)

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,9 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.0.3
+- Update `RaygunHttpModule` (Raygun4Net ASP.NET Framework) to use a singleton `RaygunClient` instance
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/537
+
 ### v11.0.2
 - Fix null signature issue when Debug Symbols are set to None and the application is built in Release mode
   - See: https://github.com/MindscapeHQ/raygun4net/pull/535 

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -438,9 +438,9 @@ namespace Mindscape.Raygun4Net
 
     private void StripAndSend(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo, DateTime? currentTime)
     {
+      var contextId = GetContextId();
       var requestMessage = BuildRequestMessage();
       IList<RaygunBreadcrumb> breadcrumbs = BuildBreadCrumbList();
-      var contextId = GetContextId();
 
       foreach (var e in StripWrapperExceptions(exception))
       {
@@ -455,9 +455,9 @@ namespace Mindscape.Raygun4Net
 
     private void StripAndSendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo, DateTime? currentTime)
     {
+      var contextId = GetContextId();
       var requestMessage = BuildRequestMessage();
       IList<RaygunBreadcrumb> breadcrumbs = BuildBreadCrumbList();
-      var contextId = GetContextId();
 
       foreach (var e in StripWrapperExceptions(exception))
       {

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -451,17 +451,6 @@ namespace Mindscape.Raygun4Net
       }
     }
 
-    private static IList<RaygunBreadcrumb> BuildBreadCrumbList()
-    {
-      IList<RaygunBreadcrumb> breadCrumbs = null;
-      foreach (var breadCrumb in _breadcrumbs)
-      {
-        breadCrumbs ??= new List<RaygunBreadcrumb>();
-        breadCrumbs.Add(breadCrumb);
-      }
-      return breadCrumbs ?? Array.Empty<RaygunBreadcrumb>();
-    }
-
     private void StripAndSendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo, DateTime? currentTime)
     {
       var requestMessage = BuildRequestMessage();
@@ -475,6 +464,17 @@ namespace Mindscape.Raygun4Net
           x.Details.Breadcrumbs = breadcrumbs;
         }));
       }
+    }
+
+    private static IList<RaygunBreadcrumb> BuildBreadCrumbList()
+    {
+      IList<RaygunBreadcrumb> breadCrumbs = null;
+      foreach (var breadCrumb in _breadcrumbs)
+      {
+        breadCrumbs ??= new List<RaygunBreadcrumb>();
+        breadCrumbs.Add(breadCrumb);
+      }
+      return breadCrumbs ?? Array.Empty<RaygunBreadcrumb>();
     }
 
     /// <summary>
@@ -600,7 +600,7 @@ namespace Mindscape.Raygun4Net
         .SetVersion(ApplicationVersion)
         .SetTags(tags)
         .SetUserCustomData(userCustomData)
-        .SetContextId(ContextId)
+        .SetContextId(GetContextId())
         .SetUser(userInfoMessage ?? UserInfo ?? (!string.IsNullOrEmpty(User) ? new RaygunIdentifierMessage(User) : null))
         .Customise(customise)
         .Build();
@@ -666,6 +666,11 @@ namespace Mindscape.Raygun4Net
       {
         yield return exception;
       }
+    }
+
+    private static string GetContextId()
+    {
+      return HttpContext.Current?.Session?.SessionID;
     }
 
     #endregion // Message Building Methods

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -440,6 +440,7 @@ namespace Mindscape.Raygun4Net
     {
       var requestMessage = BuildRequestMessage();
       IList<RaygunBreadcrumb> breadcrumbs = BuildBreadCrumbList();
+      var contextId = GetContextId();
 
       foreach (var e in StripWrapperExceptions(exception))
       {
@@ -447,6 +448,7 @@ namespace Mindscape.Raygun4Net
         {
           x.Details.Request = requestMessage;
           x.Details.Breadcrumbs = breadcrumbs;
+          x.Details.ContextId = contextId;
         }));
       }
     }
@@ -455,6 +457,7 @@ namespace Mindscape.Raygun4Net
     {
       var requestMessage = BuildRequestMessage();
       IList<RaygunBreadcrumb> breadcrumbs = BuildBreadCrumbList();
+      var contextId = GetContextId();
 
       foreach (var e in StripWrapperExceptions(exception))
       {
@@ -462,6 +465,7 @@ namespace Mindscape.Raygun4Net
         {
           x.Details.Request = requestMessage;
           x.Details.Breadcrumbs = breadcrumbs;
+          x.Details.ContextId = contextId;
         }));
       }
     }
@@ -600,7 +604,6 @@ namespace Mindscape.Raygun4Net
         .SetVersion(ApplicationVersion)
         .SetTags(tags)
         .SetUserCustomData(userCustomData)
-        .SetContextId(GetContextId())
         .SetUser(userInfoMessage ?? UserInfo ?? (!string.IsNullOrEmpty(User) ? new RaygunIdentifierMessage(User) : null))
         .Customise(customise)
         .Build();
@@ -668,7 +671,7 @@ namespace Mindscape.Raygun4Net
       }
     }
 
-    private static string GetContextId()
+    private string GetContextId()
     {
       return HttpContext.Current?.Session?.SessionID;
     }

--- a/Mindscape.Raygun4Net4/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net4/RaygunHttpModule.cs
@@ -75,12 +75,7 @@ namespace Mindscape.Raygun4Net
         return raygunApplication.GenerateRaygunClient();
       }
 
-      return _raygunClient ??= GenerateDefaultRaygunClient();
-    }
-
-    private static RaygunClient GenerateDefaultRaygunClient()
-    {
-      return new RaygunClient();
+      return _raygunClient ??= new RaygunClient();
     }
 
     protected bool CanSend(Exception exception)

--- a/Mindscape.Raygun4Net4/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net4/RaygunHttpModule.cs
@@ -8,6 +8,8 @@ namespace Mindscape.Raygun4Net
 {
   public class RaygunHttpModule : IHttpModule
   {
+    private RaygunClient _raygunClient;
+
     private bool ExcludeErrorsBasedOnHttpStatusCode { get; set; }
 
     private bool ExcludeErrorsFromLocal { get; set; }
@@ -68,11 +70,17 @@ namespace Mindscape.Raygun4Net
 
     protected RaygunClient GetRaygunClient(HttpApplication application)
     {
-      var raygunApplication = application as IRaygunApplication;
-      return raygunApplication != null ? raygunApplication.GenerateRaygunClient() : GenerateDefaultRaygunClient(application);
+      if (_raygunClient == null)
+      {
+        _raygunClient = application is IRaygunApplication raygunApplication
+          ? raygunApplication.GenerateRaygunClient()
+          : GenerateDefaultRaygunClient();
+      }
+
+      return _raygunClient;
     }
 
-    private RaygunClient GenerateDefaultRaygunClient(HttpApplication application)
+    private static RaygunClient GenerateDefaultRaygunClient()
     {
       var instance = new RaygunClient();
 

--- a/Mindscape.Raygun4Net4/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net4/RaygunHttpModule.cs
@@ -82,14 +82,7 @@ namespace Mindscape.Raygun4Net
 
     private static RaygunClient GenerateDefaultRaygunClient()
     {
-      var instance = new RaygunClient();
-
-      if (HttpContext.Current != null && HttpContext.Current.Session != null)
-      {
-        instance.ContextId = HttpContext.Current.Session.SessionID;
-      }
-
-      return instance;
+      return new RaygunClient();
     }
 
     protected bool CanSend(Exception exception)

--- a/Mindscape.Raygun4Net4/RaygunHttpModule.cs
+++ b/Mindscape.Raygun4Net4/RaygunHttpModule.cs
@@ -70,14 +70,12 @@ namespace Mindscape.Raygun4Net
 
     protected RaygunClient GetRaygunClient(HttpApplication application)
     {
-      if (_raygunClient == null)
+      if (application is IRaygunApplication raygunApplication)
       {
-        _raygunClient = application is IRaygunApplication raygunApplication
-          ? raygunApplication.GenerateRaygunClient()
-          : GenerateDefaultRaygunClient();
+        return raygunApplication.GenerateRaygunClient();
       }
 
-      return _raygunClient;
+      return _raygunClient ??= GenerateDefaultRaygunClient();
     }
 
     private static RaygunClient GenerateDefaultRaygunClient()


### PR DESCRIPTION
# Description
Update the `RaygunHttpModule` for ASP.NET Framework applications to store and use a single `RaygunClient` instance. This avoids a new `RaygunClient` and in turn a `ThrottledBackgroundMessageProcessor`, from being created for every exception handled by the `RaygunHttpModule`. The `ThrottledBackgroundMessageProcessor` creates a number of background worker threads, so instantiating it for each exception can be costly.