### PR TITLE
fix: PEDebugInformation properties as nullable

### DIFF
--- a/Mindscape.Raygun4Net.Core/Diagnostics/PEDebugInformation.cs
+++ b/Mindscape.Raygun4Net.Core/Diagnostics/PEDebugInformation.cs
@@ -4,24 +4,25 @@ namespace Mindscape.Raygun4Net.Diagnostics;
 
 public sealed class PEDebugInformation
 {
+#nullable enable
   /// <summary>
   /// The signature of the PE and PDB linking them together - usually a GUID
   /// </summary>
-  public string Signature { get; internal set; }
+  public string? Signature { get; internal set; }
   
   /// <summary>
   /// Checksum of the PE & PDB. Format: {algorithm}:{hash:X}
   /// </summary>
-  public string Checksum { get; internal set; }
+  public string? Checksum { get; internal set; }
   
   /// <summary>
   /// The full location of the PDB at build time
   /// </summary>
-  public string File { get; internal set; }
+  public string? File { get; internal set; }
   
   /// <summary>
   /// The generated Timestamp of the code at build time stored as hex
   /// </summary>
-  public string Timestamp { get; internal set; }
+  public string? Timestamp { get; internal set; }
   
 }


### PR DESCRIPTION
Part of the solution for the issue reported here: https://raygun.com/forums/thread/186975#187021

As discussed internally on Slack, when running a Raygun4MAUI client, we saw an issue in which the null check for the `Signature` property was not correctly done, and we had the suspicion that the compiler was optimizing the code because `Signature` was not declared as nullable, so the null check may be removed.

So I tried to set this as nullable, packaged a set of `nupkg` using the `pack-all` script, and imported them locally in the Raygun4MAUI solution. Then compiled and run the project (both directly in "debug" and as a "release" APK), and I couldn't reproduce the issue anymore following the same steps.

cc. @ProRedCat @PanosNB 