### PR TITLE
Build message before queuing it

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,9 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.0.4
+- Fix issue with `RaygunClientBase` where `SendInBackground` deferred building the message until late, losing HttpContext
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/540
+
 ### v11.0.3
 - Update `RaygunHttpModule` (Raygun4Net ASP.NET Framework) to use a singleton `RaygunClient` instance
   - See: https://github.com/MindscapeHQ/raygun4net/pull/537


### PR DESCRIPTION
This change is required for updates to Serilog provider where Serilog uses the base implementation of `SendInBackground` but depends on `IRaygunUserProvider` to get the user info from `HttpContextAccessor.HttpContext`

When the build message is sent as a delegate to `Enqueue` it gets executed out of context and the information is lost. 

There is a minor overhead in memory building the message up front but this only occurs when there's a huge number of exceptions being thrown. 