### PR TITLE
Updated ThrottledBackgroundMessageProcessor to dynamically create task workers

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -3,6 +3,9 @@
 ### v11.0.4
 - Fix issue with `RaygunClientBase` where `SendInBackground` deferred building the message until late, losing HttpContext
   - See: https://github.com/MindscapeHQ/raygun4net/pull/540
+- Fix issue with `ThrottledBackgroundMessageProcessor` where it would hold up to 8 task threads even when idle
+  - Task Workers are now created as needed and are disposed when not needed or idle
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/542
 
 ### v11.0.3
 - Update `RaygunHttpModule` (Raygun4Net ASP.NET Framework) to use a singleton `RaygunClient` instance

--- a/Mindscape.Raygun4Net.NetCore.Common/Offline/OfflineStoreBase.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Offline/OfflineStoreBase.cs
@@ -44,14 +44,14 @@ public abstract class OfflineStoreBase
         }
         catch (Exception ex)
         {
-          Debug.WriteLine($"Exception sending offline error [{crashReport.Id}]: {ex}");
+          Trace.WriteLine($"Exception sending offline error [{crashReport.Id}]: {ex}");
           throw;
         }
       }
     }
     catch (Exception ex)
     {
-      Debug.WriteLine($"Exception sending offline errors: {ex}");
+      Trace.WriteLine($"Exception sending offline errors: {ex}");
     }
   }
 

--- a/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/RaygunClientBase.cs
@@ -124,7 +124,7 @@ namespace Mindscape.Raygun4Net
     {
       _client = client ?? DefaultClient;
       _settings = settings;
-      _backgroundMessageProcessor = new ThrottledBackgroundMessageProcessor(settings.BackgroundMessageQueueMax, _settings.BackgroundMessageWorkerCount, Send);
+      _backgroundMessageProcessor = new ThrottledBackgroundMessageProcessor(settings.BackgroundMessageQueueMax, _settings.BackgroundMessageWorkerCount, _settings.BackgroundMessageWorkerBreakpoint, Send);
       _userProvider = userProvider;
 
       _wrapperExceptions.Add(typeof(TargetInvocationException));

--- a/Mindscape.Raygun4Net.NetCore.Common/RaygunSettingsBase.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/RaygunSettingsBase.cs
@@ -32,10 +32,10 @@ public abstract class RaygunSettingsBase
   public string ApplicationVersion { get; set; }
 
   /// <summary>
-  /// If set to true will automatically setup handlers to catch Unhandled Exceptions
+  /// If set to true will automatically set up handlers to catch Unhandled Exceptions
   /// </summary>
   /// <remarks>
-  /// Currently defaults to false. This may be change in future releases.
+  /// Currently defaults to false. This may be changed in future releases.
   /// </remarks>
   public bool CatchUnhandledExceptions { get; set; } = false;
 
@@ -45,12 +45,20 @@ public abstract class RaygunSettingsBase
   public int BackgroundMessageQueueMax { get; } = ushort.MaxValue;
 
   /// <summary>
-  /// Controls the number of background threads used to process the raygun message queue
+  /// Controls the maximum number of background threads used to process the raygun message queue
   /// </summary>
   /// <remarks>
   /// Defaults to Environment.ProcessorCount * 2 &gt;= 8 ? 8 : Environment.ProcessorCount * 2
   /// </remarks>
   public int BackgroundMessageWorkerCount { get; set; } = Environment.ProcessorCount * 2 >= 8 ? 8 : Environment.ProcessorCount * 2;
+
+  /// <summary>
+  /// Used to determine how many messages are in the queue before the background processor will add another worker to help process the queue.
+  /// </summary>
+  /// <remarks>
+  /// Defaults to 25, workers will be added for every 25 messages in the queue, until the BackgroundMessageWorkerCount is reached.
+  /// </remarks>
+  public int BackgroundMessageWorkerBreakpoint { get; set; } = 25;
 
   /// <summary>
   /// A list of Environment Variables to include with the message.

--- a/Mindscape.Raygun4Net.NetCore.Common/ThrottledBackgroundMessageProcessor.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/ThrottledBackgroundMessageProcessor.cs
@@ -2,8 +2,8 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,11 +12,15 @@ namespace Mindscape.Raygun4Net
   internal sealed class ThrottledBackgroundMessageProcessor : IDisposable
   {
     private readonly BlockingCollection<Func<Task<RaygunMessage>>> _messageQueue;
-    private readonly List<Task> _workerTasks;
-    private readonly CancellationTokenSource _cancelProcessingSource;
+    private readonly ConcurrentDictionary<Task, CancellationTokenSource> _workerTasks;
+    private readonly CancellationTokenSource _globalCancellationSource;
     private readonly Func<RaygunMessage, CancellationToken, Task> _processCallback;
     private readonly int _maxWorkerTasks;
-    private readonly object _workerTaskMutex = new object();
+    private readonly object _workerTaskMutex = new();
+
+    //TODO: Make QueueSizePerWorker configurable
+    private const int QueueSizePerWorker = 25;
+
 
     private volatile bool _isDisposing;
 
@@ -28,8 +32,8 @@ namespace Mindscape.Raygun4Net
       _processCallback = onProcessMessageFunc ?? throw new ArgumentNullException(nameof(onProcessMessageFunc));
       _maxWorkerTasks = maxWorkerTasks;
       _messageQueue = new BlockingCollection<Func<Task<RaygunMessage>>>(maxQueueSize);
-      _cancelProcessingSource = new CancellationTokenSource();
-      _workerTasks = new List<Task>();
+      _globalCancellationSource = new CancellationTokenSource();
+      _workerTasks = new ConcurrentDictionary<Task, CancellationTokenSource>(Environment.ProcessorCount, _maxWorkerTasks);
     }
 
     public bool Enqueue(RaygunMessage message)
@@ -44,18 +48,29 @@ namespace Mindscape.Raygun4Net
 
     public bool Enqueue(Func<Task<RaygunMessage>> messageFunc)
     {
+      if (_isDisposing)
+      {
+        return false;
+      }
+
       var itemAdded = _messageQueue.TryAdd(messageFunc);
 
-      EnsureWorkers();
+      if (itemAdded)
+      {
+        // After enqueuing a message, adjust the number of workers in case there's currently 0 workers
+        // Otherwise there might be none and the message will never be sent...
+        AdjustWorkers();
+      }
 
       return itemAdded;
     }
 
-    private void EnsureWorkers()
+    /// <summary>
+    /// This method uses the queue size to determine the number of workers that should be processing messages.
+    /// </summary>
+    private void AdjustWorkers()
     {
-      // If we are in the process of disposing or  something else has the lock,
-      // then it's going to update the workers
-      // so we can just early return, and not perform any work
+      // We only want one thread to adjust the number of workers at a time
       if (_isDisposing || !Monitor.TryEnter(_workerTaskMutex))
       {
         return;
@@ -63,19 +78,136 @@ namespace Mindscape.Raygun4Net
 
       try
       {
-        // Remove dead/faulted/finished tasks
-        _workerTasks.RemoveAll(x => x.IsCompleted);
+        // Remove any completed tasks, otherwise we might not have space to add new tasks that want to do work
+        RemoveCompletedTasks();
 
-        var numberOfWorkersToStart = _maxWorkerTasks - _workerTasks.Count;
+        // Calculate the desired number of workers based on the queue size, this is so we don't end up creating
+        // many workers that essentially do nothing, or if there's a small number of errors we don't have too many workers
+        var queueSize = _messageQueue.Count;
+        var currentWorkers = _workerTasks.Count;
+        var desiredWorkers = CalculateDesiredWorkers(queueSize);
 
-        for (var i = 0; i < numberOfWorkersToStart; i++)
+        if (desiredWorkers > currentWorkers)
         {
-          _workerTasks.Add(CreateWorkerTask());
+          for (var i = currentWorkers; i < desiredWorkers; i++)
+          {
+            CreateWorkerTask();
+          }
+        }
+        else if (desiredWorkers < currentWorkers)
+        {
+          RemoveExcessWorkers(currentWorkers - desiredWorkers);
         }
       }
       finally
       {
+        // Make sure we release the mutex otherwise we'll block the next thread that wants to adjust the number of workers
         Monitor.Exit(_workerTaskMutex);
+      }
+    }
+
+    /// <summary>
+    /// A task may be in a completed state but not yet removed from the dictionary. This method removes any completed tasks.
+    /// Completed means the task has finished executing, whether it was successful or not. (Failed, Successful, Faulted, etc.)
+    /// </summary>
+    private void RemoveCompletedTasks()
+    {
+      var completedTasks = _workerTasks.Where(kvp => kvp.Key.IsCompleted).ToArray();
+      
+      foreach (var kvp in completedTasks)
+      {
+        if (_workerTasks.TryRemove(kvp.Key, out var cts))
+        {
+          cts.Dispose();
+        }
+      }
+    }
+
+    /// <summary>
+    /// When the number of workers is greater than the desired number, remove the excess workers.
+    /// We do this by taking the first N workers and cancelling them.
+    /// Then we dispose of the CancellationTokenSource.
+    /// </summary>
+    /// <param name="count">Number of workers to kill off.</param>
+    private void RemoveExcessWorkers(int count)
+    {
+      var excessWorkers = _workerTasks.Take(count).ToArray();
+
+      foreach (var kvp in excessWorkers)
+      {
+        if (_workerTasks.TryRemove(kvp.Key, out var cts))
+        {
+          cts.Cancel();
+          cts.Dispose();
+        }
+      }
+    }
+
+    /// <summary>
+    /// Spin up a new worker task to process messages. This method is called by AdjustWorkers when the number of workers is less than the desired number.
+    /// When a task completes it will adjust the number of workers again in case the queue size has changed.
+    /// </summary>
+    private void CreateWorkerTask()
+    {
+      var cts = CancellationTokenSource.CreateLinkedTokenSource(_globalCancellationSource.Token);
+      var task = Task.Run(() => RaygunMessageWorker(_messageQueue, _processCallback, cts.Token), _globalCancellationSource.Token);
+
+      _workerTasks[task] = cts;
+
+      // When the worker task completes, adjust the number of workers
+      task.ContinueWith(_ => AdjustWorkers(), TaskContinuationOptions.ExecuteSynchronously);
+    }
+
+    /// <summary>
+    /// Calculate the desired number of workers based on the queue size. This method is used by AdjustWorkers.
+    /// </summary>
+    private int CalculateDesiredWorkers(int queueSize)
+    {
+      if (queueSize == 0)
+      {
+        return 0;
+      }
+
+      if (queueSize <= QueueSizePerWorker)
+      {
+        return 1;
+      }
+
+      return Math.Min((queueSize + QueueSizePerWorker - 1) / QueueSizePerWorker, _maxWorkerTasks);
+    }
+
+    /// <summary>
+    /// Actual task run by the worker. This method will take a message from the queue and process it.
+    /// </summary>
+    private static async Task RaygunMessageWorker(BlockingCollection<Func<Task<RaygunMessage>>> messageQueue,
+                                                  Func<RaygunMessage, CancellationToken, Task> callback,
+                                                  CancellationToken cancellationToken)
+    {
+      try
+      {
+        while (!cancellationToken.IsCancellationRequested && !messageQueue.IsCompleted)
+        {
+          Func<Task<RaygunMessage>> messageFunc;
+          try
+          {
+            messageFunc = messageQueue.Take(cancellationToken);
+          }
+          catch (InvalidOperationException) when (messageQueue.IsCompleted)
+          {
+            break;
+          }
+
+          var message = await messageFunc();
+          await callback(message, cancellationToken);
+        }
+      }
+      catch (OperationCanceledException)
+      {
+        // Task was cancelled, this is expected behavior
+      }
+      catch (Exception ex)
+      {
+        Debug.WriteLine($"Exception in queue worker: {ex}");
       }
     }
 
@@ -89,50 +221,18 @@ namespace Mindscape.Raygun4Net
       _isDisposing = true;
 
       _messageQueue.CompleteAdding();
-      _cancelProcessingSource.Cancel();
+      _globalCancellationSource.Cancel();
+
+      foreach (var kvp in _workerTasks)
+      {
+        kvp.Value.Cancel();
+        kvp.Value.Dispose();
+      }
+
+      Task.WaitAll(_workerTasks.Keys.ToArray(), TimeSpan.FromSeconds(2));
+
       _messageQueue.Dispose();
-
-      // Wait a few seconds for the workers to finish gracefully
-      Task.WhenAll(_workerTasks).Wait(TimeSpan.FromSeconds(2));
-    }
-
-    private Task CreateWorkerTask()
-    {
-      var workerTask = Task.Run(async () =>
-      {
-        // Run the message processor loop
-        await RaygunMessageWorker(_messageQueue, _processCallback, _cancelProcessingSource.Token);
-      });
-
-      // When a worker finishes ensure that a new one is is created if required
-      workerTask.ContinueWith(x => { EnsureWorkers(); });
-
-      return workerTask;
-    }
-
-    private static async Task RaygunMessageWorker(
-      BlockingCollection<Func<Task<RaygunMessage>>> messageQueue,
-      Func<RaygunMessage, CancellationToken, Task> callback,
-      CancellationToken cancellationToken)
-    {
-      try
-      {
-        foreach (var messageFunc in messageQueue.GetConsumingEnumerable(cancellationToken))
-        {
-          var message = await messageFunc();
-          await callback(message, cancellationToken);
-        }
-      }
-      catch (Exception cancelledEx) when (cancelledEx is ThreadAbortException ||
-                                          cancelledEx is OperationCanceledException ||
-                                          cancelledEx is TaskCanceledException)
-      {
-        // Cancellation was requested, so it's fine
-      }
-      catch (Exception ex)
-      {
-        Debug.WriteLine("Exception in queue worker {0}: {1}", Task.CurrentId, ex);
-      }
+      _globalCancellationSource.Dispose();
     }
   }
 }

--- a/Mindscape.Raygun4Net.NetCore.Tests/ThrottledBackgroundMessageProcessorTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/ThrottledBackgroundMessageProcessorTests.cs
@@ -180,7 +180,6 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
       }
 
       Assert.That(secondMessageWasProcessed, Is.True);
-      //Assert.That(secondMessageWasProcessed, Is.True);
     }
 
     [Test]
@@ -218,7 +217,6 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
       }
 
       Assert.That(secondMessageWasProcessed, Is.True);
-      //Assert.That(secondMessageWasProcessed, Is.True);
     }
   }
 }

--- a/Mindscape.Raygun4Net.NetCore/Storage/FileSystemCrashReportStore.cs
+++ b/Mindscape.Raygun4Net.NetCore/Storage/FileSystemCrashReportStore.cs
@@ -47,7 +47,7 @@ public class FileSystemCrashReportStore : OfflineStoreBase
       }
       catch (Exception ex)
       {
-        Debug.WriteLine("Error deserializing offline crash: {0}", ex.ToString());
+        Trace.WriteLine("Error deserializing offline crash: {0}", ex.ToString());
         File.Move(crashFile, $"{crashFile}.failed");
       }
     }
@@ -65,7 +65,7 @@ public class FileSystemCrashReportStore : OfflineStoreBase
       var crashFiles = Directory.GetFiles(_storageDirectory, $"*.{CacheFileExtension}");
       if (crashFiles.Length >= _maxOfflineFiles)
       {
-        Debug.WriteLine($"Maximum offline files of [{_maxOfflineFiles}] has been reached");
+        Trace.WriteLine($"Maximum offline files of [{_maxOfflineFiles}] has been reached");
         return false;
       }
 
@@ -90,7 +90,7 @@ public class FileSystemCrashReportStore : OfflineStoreBase
     }
     catch (Exception ex)
     {
-      Debug.WriteLine($"Error adding crash [{cacheEntryId}] to store: {ex}");
+      Trace.WriteLine($"Error adding crash [{cacheEntryId}] to store: {ex}");
       return false;
     }
   }
@@ -108,7 +108,7 @@ public class FileSystemCrashReportStore : OfflineStoreBase
     }
     catch (Exception ex)
     {
-      Debug.WriteLine($"Error remove crash [{cacheId}] from store: {ex}");
+      Trace.WriteLine($"Error remove crash [{cacheId}] from store: {ex}");
     }
 
     return Task.FromResult(false);


### PR DESCRIPTION
Should resolve #541 where up to 8 tasks workers can sit idle doing nothing when there's no messages to be sent. This change will create the task workers on demand based on the queue length and dispose of them if idle. 
