### PR TITLE
Prevent exception from being thrown and then immediately caught when getting debug information

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,9 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.1.1
+- Prevented a null reference exception from being thrown after a PortableExecutable (PE) fails to be loaded from disk
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/544
+
 ### v11.1.0
 - Fix issue with `RaygunClientBase` where `SendInBackground` deferred building the message until late, losing HttpContext
   - See: https://github.com/MindscapeHQ/raygun4net/pull/540

--- a/Mindscape.Raygun4Net.Core/Diagnostics/PortableExecutableReaderExtensions.cs
+++ b/Mindscape.Raygun4Net.Core/Diagnostics/PortableExecutableReaderExtensions.cs
@@ -26,6 +26,12 @@ internal static class PortableExecutableReaderExtensions
 
   public static bool TryGetDebugInformation(this PEReader peReader, out PEDebugInformation debugInformation)
   {
+    if (peReader is null)
+    {
+      debugInformation = null;
+      return false;
+    }
+
     try
     {
       debugInformation = GetDebugInformation(peReader);

--- a/Mindscape.Raygun4Net.NetCore.Common/Diagnostics/PortableExecutableReaderExtensions.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Diagnostics/PortableExecutableReaderExtensions.cs
@@ -26,8 +26,14 @@ internal static class PortableExecutableReaderExtensions
     }
   }
 
-  public static bool TryGetDebugInformation(this PEReader peReader, out PEDebugInformation? debugInformation)
+  public static bool TryGetDebugInformation(this PEReader? peReader, out PEDebugInformation? debugInformation)
   {
+    if (peReader is null)
+    {
+      debugInformation = null;
+      return false;
+    }
+
     try
     {
       debugInformation = GetDebugInformation(peReader);


### PR DESCRIPTION
This change is to prevent an exception from being thrown and then immediately caught within the `TryGetDebugInformation` method.
Its possible that in certain circumstances, a stack frame originates from a module that only exists in memory. In this situation, the name of the module will not be a locaiton on disk so loading that module from disk will fail. This causes the `PEReader` to be null.