### PR TITLE
Fixed issue where Uri/Guid couldn't be serialized

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,9 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.1.2
+- Fixed issue with SimpleJson where Uri/Guid couldn't be serialized.
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/546
+
 ### v11.1.1
 - Prevented a null reference exception from being thrown after a PortableExecutable (PE) fails to be loaded from disk
   - See: https://github.com/MindscapeHQ/raygun4net/pull/544

--- a/Mindscape.Raygun4Net.Core/SimpleJson.cs
+++ b/Mindscape.Raygun4Net.Core/SimpleJson.cs
@@ -1020,19 +1020,21 @@ namespace Mindscape.Raygun4Net
         return false;
       }
 
-      if (visited.Contains(value))
-      {
-        return SerializeString(CYCLIC_MESSAGE, builder); 
-      }
-
-      visited.Push(value);
-
       bool success = true;
       string stringValue = value as string;
       if (stringValue != null)
+      {
         success = SerializeString(stringValue, builder);
+      }
       else
       {
+        if (visited.Contains(value))
+        {
+          return SerializeString(CYCLIC_MESSAGE, builder);
+        }
+
+        visited.Push(value);
+        
         if (value.GetType().IsArray)
         {
           success = SerializeArray(jsonSerializerStrategy, value as IEnumerable, builder, visited);
@@ -1080,11 +1082,11 @@ namespace Mindscape.Raygun4Net
             }
           }
         }
-      }
 
-      if (visited.Count > 0) // Just to be safe
-      {
-        visited.Pop();
+        if (visited.Count > 0) // Just to be safe
+        {
+          visited.Pop();
+        }
       }
 
       return success;

--- a/Mindscape.Raygun4Net.NetCore.Common/SimpleJson.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/SimpleJson.cs
@@ -1020,19 +1020,21 @@ namespace Mindscape.Raygun4Net
         return false;
       }
 
-      if (visited.Contains(value))
-      {
-        return SerializeString(CYCLIC_MESSAGE, builder); ;
-      }
-
-      visited.Push(value);
-
       bool success = true;
       string stringValue = value as string;
       if (stringValue != null)
+      {
         success = SerializeString(stringValue, builder);
+      }
       else
       {
+        if (visited.Contains(value))
+        {
+          return SerializeString(CYCLIC_MESSAGE, builder);
+        }
+
+        visited.Push(value);
+        
         if (value.GetType().IsArray)
         {
           success = SerializeArray(jsonSerializerStrategy, value as IEnumerable, builder, visited);
@@ -1080,11 +1082,11 @@ namespace Mindscape.Raygun4Net
             }
           }
         }
-      }
 
-      if (visited.Count > 0) // Just to be safe
-      {
-        visited.Pop();
+        if (visited.Count > 0) // Just to be safe
+        {
+          visited.Pop();
+        }
       }
 
       return success;

--- a/Mindscape.Raygun4Net.NetCore.Tests/SimpleJsonTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/SimpleJsonTests.cs
@@ -179,5 +179,41 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
       string json = SimpleJson.SerializeObject(cyclicObject);
       Assert.That("{\"Array\":[null],\"Dictionary\":{\"Key1\":\"" + SimpleJson.CYCLIC_MESSAGE + "\"," + "\"Key2\":\"" + SimpleJson.CYCLIC_MESSAGE + "\"," + "\"Key3\":\"" + SimpleJson.CYCLIC_MESSAGE + "\"," + "\"Key4\":\"" + SimpleJson.CYCLIC_MESSAGE + "\"},\"GenericDictionary\":{}}", Is.EqualTo(json));
     }
+
+    [Test]
+    public void HandleUri()
+    {
+      var testUri = new TestUri
+      {
+        Test = new Uri("http://www.google.com")
+      };
+      
+      var result = SimpleJson.SerializeObject(testUri);
+      
+      Assert.That("{\"Test\":\"http://www.google.com/\"}", Is.EqualTo(result));
+    }
+    
+    [Test]
+    public void HandleGuid()
+    {
+      var testGuid = new TestGuid
+      {
+        Test = Guid.NewGuid()
+      };
+      
+      var result = SimpleJson.SerializeObject(testGuid);
+      
+      Assert.That("{\"Test\":\"" + testGuid.Test + "\"}", Is.EqualTo(result));
+    }
+
+    public class TestGuid
+    {
+      public Guid Test { get; set; }
+    }
+
+    public class TestUri
+    {
+      public Uri Test { get; set; }
+    }
   }
 }


### PR DESCRIPTION
Fixes issue #307 where types that call `.ToString()` end up with `[Circular reference detected, object not serialized]` instead of the `ToString()` value.