### PR TITLE
Filter out __RestrictedErrorObjectReference

### DIFF
--- a/Mindscape.Raygun4Net.NetCore.Common/Builders/RaygunErrorMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Builders/RaygunErrorMessageBuilder.cs
@@ -18,7 +18,7 @@ namespace Mindscape.Raygun4Net
 
     private static readonly HashSet<string> IgnoredExceptionDataKeys =
     [
-      "__RestrictedErrorObjectReference"
+      "__RestrictedErrorObjectReference" // Seen on WinRT exceptions. This maps to a WinRT.ObjectReferenceWithContext<WinRT.Interop.IUnknownVftbl> which will crash the app with an uncatchable AccessViolationException if attempting serialization.
     ];
 
     protected static string FormatTypeName(Type type, bool fullName)

--- a/Mindscape.Raygun4Net.NetCore.Common/Builders/RaygunErrorMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Builders/RaygunErrorMessageBuilder.cs
@@ -16,6 +16,11 @@ namespace Mindscape.Raygun4Net
     private static readonly ConcurrentDictionary<string, PEDebugInformation> DebugInformationCache = new();
     public static Func<string, PEReader> AssemblyReaderProvider { get; set; } = PortableExecutableReaderExtensions.GetFileSystemPEReader;
 
+    private static readonly HashSet<string> IgnoredExceptionDataKeys =
+    [
+      "__RestrictedErrorObjectReference"
+    ];
+
     protected static string FormatTypeName(Type type, bool fullName)
     {
       string name = fullName ? type.FullName : type.Name;
@@ -188,7 +193,7 @@ namespace Mindscape.Raygun4Net
 
         foreach (var key in exception.Data.Keys)
         {
-          if (!RaygunClientBase.SentKey.Equals(key))
+          if (!RaygunClientBase.SentKey.Equals(key) && !IgnoredExceptionDataKeys.Contains(key))
           {
             data[key] = exception.Data[key];
           }


### PR DESCRIPTION
Addresses https://github.com/MindscapeHQ/raygun4net/issues/547

WinRT exceptions can have a value in the Exception.Data dictionary with a key of "__RestrictedErrorObjectReference" and a value of type WinRT.ObjectReferenceWithContext<WinRT.Interop.IUnknownVftbl>. When trying to serialize this value, a System.AccessViolationException is thrown which can crash the application, even if caught.

This PR is a candidate fix for this issue which take the approach of recognizing the Data dictionary key and not including the value in the report sent to Raygun.