### PR TITLE
Fix client name

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,6 +1,8 @@
 # Full Change Log for Raygun4Net.* packages
 
 ### v11.1.3
+- Skip serializing `WinRT.ObjectReferenceWithContext<WinRT.Interop.IUnknownVftbl>` objects attached to the Exception.Data to avoid AccessViolationException.
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/549
 - Fixed Client.Name in Raygun4Net to fix group hasher breaking
   - See: https://github.com/MindscapeHQ/raygun4net/pull/551
 

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,9 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.1.3
+- Fixed Client.Name in Raygun4Net to fix group hasher breaking
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/551
+
 ### v11.1.2
 - Fixed issue with SimpleJson where Uri/Guid couldn't be serialized.
   - See: https://github.com/MindscapeHQ/raygun4net/pull/546

--- a/Mindscape.Raygun4Net.Core/Messages/RaygunClientMessage.cs
+++ b/Mindscape.Raygun4Net.Core/Messages/RaygunClientMessage.cs
@@ -6,8 +6,7 @@ namespace Mindscape.Raygun4Net.Messages
   {
     public RaygunClientMessage()
     {
-      object[] attributes = GetType().Assembly.GetCustomAttributes(typeof(AssemblyTitleAttribute), false);
-      Name = attributes.Length > 0 ? ((AssemblyTitleAttribute)attributes[0]).Title : "Raygun4Net";
+      Name = "Raygun4Net";
       Version = new AssemblyName(GetType().Assembly.FullName).Version.ToString();
       ClientUrl = @"https://github.com/MindscapeHQ/raygun4net";
     }
@@ -22,7 +21,7 @@ namespace Mindscape.Raygun4Net.Messages
     {
       // This exists because Reflection in Xamarin can't seem to obtain the Getter methods unless the getter is used somewhere in the code.
       // The getter of all properties is required to serialize the Raygun messages to JSON.
-      return string.Format("[RaygunClientMessage: Name={0}, Version={1}, ClientUrl={2}]", Name, Version, ClientUrl);
+      return $"[RaygunClientMessage: Name={Name}, Version={Version}, ClientUrl={ClientUrl}]";
     }
   }
 }


### PR DESCRIPTION
When we has Assembly Info files in the old project files, this defaulted to `Raygun4Net` or similar, but the removal of the assembly info and move to new project files meant its set to `Mindscape.Raygun4Net` which unintentionally broke the grouping hasher for .NET Framework projects.

This removes looking up based on the Title and hard codes it to Raygun4Net so it doesn't break.