### PR TITLE
Fixed user provider resolving

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/ApplicationBuilderExtensions.cs
@@ -52,7 +52,7 @@ public static class ApplicationBuilderExtensions
     options?.Invoke(settings);
 
     services.TryAddSingleton(settings);
-    services.TryAddSingleton(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetRequiredService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
+    services.TryAddSingleton(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
     services.TryAddSingleton<RaygunClientBase>(provider => provider.GetRequiredService<RaygunClient>());
     services.AddHttpContextAccessor();
 
@@ -72,7 +72,7 @@ public static class ApplicationBuilderExtensions
     
     services.TryAddSingleton<IMessageBuilder, RequestDataBuilder>();
     services.TryAddSingleton(settings);
-    services.TryAddSingleton(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetRequiredService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
+    services.TryAddSingleton(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
     services.TryAddSingleton<RaygunClientBase>(provider => provider.GetRequiredService<RaygunClient>());
     services.AddHttpContextAccessor();
 

--- a/Mindscape.Raygun4Net.NetCore/ApplicationBuilderExtensions.cs
+++ b/Mindscape.Raygun4Net.NetCore/ApplicationBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class ApplicationBuilderExtensions
     options?.Invoke(settings);
 
     services.TryAddSingleton(settings);
-    services.TryAddSingleton<RaygunClientBase>(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetRequiredService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
+    services.TryAddSingleton<RaygunClientBase>(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
 
     return services;
   }
@@ -40,7 +40,7 @@ public static class ApplicationBuilderExtensions
     options?.Invoke(settings);
     
     services.TryAddSingleton(settings);
-    services.TryAddSingleton<RaygunClientBase>(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetRequiredService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
+    services.TryAddSingleton<RaygunClientBase>(s => new RaygunClient(s.GetRequiredService<RaygunSettings>(), s.GetService<IRaygunUserProvider>(), s.GetServices<IMessageBuilder>()));
 
     return services;
   }

--- a/Raygun4Net.MSLogger.AspNetCore.Tests/Program.cs
+++ b/Raygun4Net.MSLogger.AspNetCore.Tests/Program.cs
@@ -15,7 +15,7 @@ builder.Services.AddRaygun(settings =>
 builder.Services.AddSingleton<IMessageBuilder, DefaultTags>();
    
 // (Optional) Registers the Raygun User Provider
-builder.Services.AddRaygunUserProvider();
+// builder.Services.AddRaygunUserProvider();
 
 // Registers the Raygun Logger for use in MS Logger
 builder.Logging.AddRaygunLogger(x =>


### PR DESCRIPTION
Fixes #554 

Changed `GetService` to `GetRequiredService` for settings, and inadvertently changed the one for `IRaygunUserProvider` also.

Reproduced the issue by commenting out 
```
builder.Services.AddRaygunUserProvider();
```

Changed it to `GetService` app functions correctly again.