### PR TITLE
fix: Add DynamicDependency declaration to preserve MarshalManagedException in iOS and MacOS apps

### DIFF
--- a/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
@@ -13,10 +13,15 @@ namespace Mindscape.Raygun4Net.Platforms
 
     private static object MarshalManagedExceptionMode_UnwindNativeCode;
 
+#if NET6_0_OR_GREATER
+    // Preserves the MarshalManagedException method and MarshalManagedExceptionMode enum
+    // from being trimmed by the compiler.
+    // Not supported in netstandard2.0.
     [DynamicDependency("MarshalManagedException", "ObjCRuntime.Runtime", "Microsoft.iOS")]
     [DynamicDependency("MarshalManagedExceptionMode", "ObjCRuntime", "Microsoft.iOS")]
     [DynamicDependency("MarshalManagedException", "ObjCRuntime.Runtime", "Microsoft.MacCatalyst")]
     [DynamicDependency("MarshalManagedExceptionMode", "ObjCRuntime", "Microsoft.MacCatalyst")]
+#endif
     public static bool TryAttachExceptionHandlers()
     {
       try

--- a/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
@@ -1,17 +1,21 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Mindscape.Raygun4Net.Platforms
 {
   internal static class ApplePlatform
   {
+
     private static Assembly IOSAssembly;
 
     private static Assembly MacCatalystAssembly;
 
     private static object MarshalManagedExceptionMode_UnwindNativeCode;
 
+    [DynamicDependency("MarshalManagedException", "ObjCRuntime.Runtime", "Microsoft.iOS")]
+    [DynamicDependency("MarshalManagedExceptionMode", "ObjCRuntime", "Microsoft.iOS")]
     public static bool TryAttachExceptionHandlers()
     {
       try

--- a/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
@@ -16,6 +16,8 @@ namespace Mindscape.Raygun4Net.Platforms
 
     [DynamicDependency("MarshalManagedException", "ObjCRuntime.Runtime", "Microsoft.iOS")]
     [DynamicDependency("MarshalManagedExceptionMode", "ObjCRuntime", "Microsoft.iOS")]
+    [DynamicDependency("MarshalManagedException", "ObjCRuntime.Runtime", "Microsoft.MacCatalyst")]
+    [DynamicDependency("MarshalManagedExceptionMode", "ObjCRuntime", "Microsoft.MacCatalyst")]
     public static bool TryAttachExceptionHandlers()
     {
       try

--- a/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
@@ -7,7 +7,6 @@ namespace Mindscape.Raygun4Net.Platforms
 {
   internal static class ApplePlatform
   {
-
     private static Assembly IOSAssembly;
 
     private static Assembly MacCatalystAssembly;


### PR DESCRIPTION
As discussed on Slack, a customer has been facing issues where the method `MarshalManagedException` gets trimmed by the compiler, so crashes aren't captured.

The first approach I tried was to declare linker rules via xml configuration, but that only works if declared in the root project.

In order to offer a turn-key solution, I've found out that you can also declare the `DynamicDependency` directly in the class code. This will tell the compiler to not trim it. I have added it for both iOS and MacCatalyst platforms.

This has been tested using the provided sample code by the customer.