### PR TITLE
fix: add DynamicDependency definition for Windows and Android

### DIFF
--- a/Mindscape.Raygun4Net.NetCore.Common/Platforms/AndroidPlatform.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Platforms/AndroidPlatform.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Mindscape.Raygun4Net.Platforms
@@ -8,6 +9,9 @@ namespace Mindscape.Raygun4Net.Platforms
   {
     private static Assembly AndroidAssembly;
 
+#if NET6_0_OR_GREATER
+    [DynamicDependency("UnhandledExceptionRaiser", "Android.Runtime.AndroidEnvironment", "Mono.Android")]
+#endif
     public static bool TryAttachExceptionHandlers()
     {
       try

--- a/Mindscape.Raygun4Net.NetCore.Common/Platforms/WindowsPlatform.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Platforms/WindowsPlatform.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Mindscape.Raygun4Net.Platforms
@@ -10,6 +11,9 @@ namespace Mindscape.Raygun4Net.Platforms
 
     private static Exception _lastFirstChanceException;
 
+#if NET6_0_OR_GREATER
+    [DynamicDependency("UnhandledException", "Microsoft.UI.Xaml.Application", "Microsoft.WinUI")]
+#endif
     public static bool TryAttachExceptionHandlers()
     {
       try


### PR DESCRIPTION
This PR adds the dynamic dependency definition for Android and Windows platform implementations. However, I am not sure how to effectively test this, I asked on Slack about which existing example project I can use for that, otherwise I will create new example projects.