### PR TITLE
fix: #558 ported ThrottledBackgroundMessageProcessor from NetCore to Core

### DIFF
--- a/Mindscape.Raygun4Net.Core/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.Core/RaygunSettings.cs
@@ -53,6 +53,14 @@ namespace Mindscape.Raygun4Net
       set { this["backgroundMessageWorkerCount"] = value; }
     }
 
+    /// <summary>
+    /// Used to determine how many messages are in the queue before the background processor will add another worker to help process the queue.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to 25, workers will be added for every 25 messages in the queue, until the BackgroundMessageWorkerCount is reached.
+    /// </remarks>
+    public int BackgroundMessageWorkerBreakpoint { get; set; } = 25;
+
     [ConfigurationProperty("apikey", IsRequired = true, DefaultValue = "")]
     [StringValidator]
     public string ApiKey

--- a/Mindscape.Raygun4Net.NetCore.Tests/ThrottledBackgroundMessageProcessorTests.cs
+++ b/Mindscape.Raygun4Net.NetCore.Tests/ThrottledBackgroundMessageProcessorTests.cs
@@ -156,7 +156,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     }
 
     [Test]
-    public void Things_Throwing()
+    public void ThrottledBackgroundMessageProcessor_Enqueue_SingleMessage()
     {
       var secondMessageWasProcessed = false;
 
@@ -183,7 +183,7 @@ namespace Mindscape.Raygun4Net.NetCore.Tests
     }
 
     [Test]
-    public void Things_Throwing_Many()
+    public void ThrottledBackgroundMessageProcessor_Enqueue_ManyMessages()
     {
       var secondMessageWasProcessed = false;
       for (int j = 0; j < 100; j++)

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -62,6 +62,7 @@ namespace Mindscape.Raygun4Net.WebApi
       _backgroundMessageProcessor = new ThrottledBackgroundMessageProcessor(
         RaygunSettings.Settings.BackgroundMessageQueueMax,
         RaygunSettings.Settings.BackgroundMessageWorkerCount,
+        RaygunSettings.Settings.BackgroundMessageWorkerBreakpoint,
         Send);
 
       Init();
@@ -87,6 +88,7 @@ namespace Mindscape.Raygun4Net.WebApi
       _backgroundMessageProcessor = new ThrottledBackgroundMessageProcessor(
                                           RaygunSettings.Settings.BackgroundMessageQueueMax,
                                           RaygunSettings.Settings.BackgroundMessageWorkerCount,
+                                          RaygunSettings.Settings.BackgroundMessageWorkerBreakpoint,
                                           Send);
 
       Init();

--- a/Mindscape.Raygun4Net4.Tests/ThrottledBackgroundMessageProcessorTests.cs
+++ b/Mindscape.Raygun4Net4.Tests/ThrottledBackgroundMessageProcessorTests.cs
@@ -145,7 +145,7 @@ namespace Mindscape.Raygun4Net4.Tests
     }
 
     [Test]
-    public void Things_Throwing_Many()
+    public void ThrottledBackgroundMessageProcessor_Enqueue_ManyMessages()
     {
       var secondMessageWasProcessed = false;
       for (int j = 0; j < 100; j++)

--- a/Mindscape.Raygun4Net4.Tests/ThrottledBackgroundMessageProcessorTests.cs
+++ b/Mindscape.Raygun4Net4.Tests/ThrottledBackgroundMessageProcessorTests.cs
@@ -12,7 +12,7 @@ namespace Mindscape.Raygun4Net4.Tests
     [Test]
     public void ThrottledBackgroundMessageProcessor_WithQueueSpace_AcceptsMessages()
     {
-      var cut = new ThrottledBackgroundMessageProcessor(1, 0, _ => { });
+      var cut = new ThrottledBackgroundMessageProcessor(1, 0, 25, _ => { });
       var enqueued = cut.Enqueue(new RaygunMessage());
 
       Assert.That(enqueued, Is.True);
@@ -21,7 +21,7 @@ namespace Mindscape.Raygun4Net4.Tests
     [Test]
     public void ThrottledBackgroundMessageProcessor_WithFullQueue_DropsMessages()
     {
-      var cut = new ThrottledBackgroundMessageProcessor(1, 0, _ => { });
+      var cut = new ThrottledBackgroundMessageProcessor(1, 0, 25, _ => { });
       cut.Enqueue(new RaygunMessage());
       var second = cut.Enqueue(new RaygunMessage());
 
@@ -34,7 +34,7 @@ namespace Mindscape.Raygun4Net4.Tests
     public void ThrottledBackgroundMessageProcessor_WithNoWorkers_DoesNotProcessMessages()
     {
       var processed = false;
-      var cut = new ThrottledBackgroundMessageProcessor(1, 0, _ => { processed = true; });
+      var cut = new ThrottledBackgroundMessageProcessor(1, 0, 25, _ => { processed = true; });
 
       cut.Enqueue(new RaygunMessage());
 
@@ -49,7 +49,7 @@ namespace Mindscape.Raygun4Net4.Tests
     {
       var processed = false;
       var resetEventSlim = new ManualResetEventSlim();
-      var cut = new ThrottledBackgroundMessageProcessor(1, 1, _ =>
+      var cut = new ThrottledBackgroundMessageProcessor(1, 1, 25, _ =>
       {
         processed = true;
         resetEventSlim.Set();
@@ -68,7 +68,7 @@ namespace Mindscape.Raygun4Net4.Tests
     [Test]
     public void ThrottledBackgroundMessageProcessor_CallingDisposeTwice_DoesNotExplode()
     {
-      var cut = new ThrottledBackgroundMessageProcessor(1, 0, _ => { });
+      var cut = new ThrottledBackgroundMessageProcessor(1, 0, 25, _ => { });
       
       Assert.DoesNotThrow(() =>
       {
@@ -85,7 +85,7 @@ namespace Mindscape.Raygun4Net4.Tests
       var secondMessageWasProcessed = false;
       var resetEventSlim = new ManualResetEventSlim();
       
-      var cut = new ThrottledBackgroundMessageProcessor(1, 1, _ =>
+      var cut = new ThrottledBackgroundMessageProcessor(1, 1, 25, _ =>
       {
         if (shouldThrow)
         {
@@ -118,7 +118,7 @@ namespace Mindscape.Raygun4Net4.Tests
       var secondMessageWasProcessed = false;
       var resetEventSlim = new ManualResetEventSlim();
       
-      var cut = new ThrottledBackgroundMessageProcessor(1, 1, _ =>
+      var cut = new ThrottledBackgroundMessageProcessor(1, 1, 25, _ =>
       {
         if (shouldThrow)
         {

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -109,10 +109,11 @@ namespace Mindscape.Raygun4Net
 
       UseXmlRawDataFilter = RaygunSettings.Settings.UseXmlRawDataFilter;
       UseKeyValuePairRawDataFilter = RaygunSettings.Settings.UseKeyValuePairRawDataFilter;
-      
+
       _backgroundMessageProcessor = new ThrottledBackgroundMessageProcessor(
                                           RaygunSettings.Settings.BackgroundMessageQueueMax,
                                           RaygunSettings.Settings.BackgroundMessageWorkerCount,
+                                          RaygunSettings.Settings.BackgroundMessageWorkerBreakpoint,
                                           Send);
 
       ThreadPool.QueueUserWorkItem(state => { SendStoredMessages(); });
@@ -391,7 +392,7 @@ namespace Mindscape.Raygun4Net
           try
           {
             var currentTime = DateTime.UtcNow;
-            
+
             StripAndSendInBackground(exception, tags, userCustomData, userInfo, currentTime);
           }
           catch (Exception)
@@ -403,7 +404,7 @@ namespace Mindscape.Raygun4Net
               throw;
             }
           }
-          
+
           FlagAsSent(exception);
         }
       }
@@ -427,7 +428,7 @@ namespace Mindscape.Raygun4Net
     {
       SendInBackground(() => raygunMessage);
     }
-    
+
     public void SendInBackground(Func<RaygunMessage> raygunMessage)
     {
       if (!_backgroundMessageProcessor.Enqueue(raygunMessage))

--- a/Mindscape.Raygun4Net4/ThrottledBackgroundMessageProcessor.cs
+++ b/Mindscape.Raygun4Net4/ThrottledBackgroundMessageProcessor.cs
@@ -1,9 +1,11 @@
 #nullable enable
 
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Mindscape.Raygun4Net.Messages;
@@ -12,46 +14,70 @@ namespace Mindscape.Raygun4Net
 {
   internal sealed class ThrottledBackgroundMessageProcessor : IDisposable
   {
-    private readonly BlockingCollection<Func<RaygunMessage>> _messageQueue;
-    private readonly List<Task> _workerTasks;
-    private readonly CancellationTokenSource _cancelProcessingSource;
-    private readonly Action<RaygunMessage> _processCallback;
+    // This was a BlockingCollection<T> which used .Take to dequeue items, but since we will have 0 workers when the queue is empty
+    // we don't need to block the thread waiting for an item to be enqueued. A concurrent queue is more appropriate.
+    internal readonly ConcurrentQueue<RaygunMessage> _messageQueue;
+    internal readonly ConcurrentDictionary<Task, CancellationTokenSource> _workerTasks;
+
+    private readonly CancellationTokenSource _globalCancellationSource;
+    private readonly int _maxQueueSize;
+    private readonly Func<RaygunMessage, CancellationToken, Task> _processCallback;
     private readonly int _maxWorkerTasks;
-    private readonly object _workerTaskMutex = new object();
+    private readonly int _workerQueueBreakpoint;
+    private readonly object _workerTaskMutex = new();
 
-    private volatile bool _isDisposing;
+    private bool _drainingQueue;
 
-    public ThrottledBackgroundMessageProcessor(
-      int maxQueueSize, 
-      int maxWorkerTasks,
-      Action<RaygunMessage> onProcessMessageFunc)
+
+    private bool _isDisposing;
+    private readonly int _drainSize;
+
+    public ThrottledBackgroundMessageProcessor(int maxQueueSize,
+                                               int maxWorkerTasks,
+                                               int workerQueueBreakpoint,
+                                               Func<RaygunMessage, CancellationToken, Task> onProcessMessageFunc)
     {
+      _maxQueueSize = maxQueueSize;
+      _workerQueueBreakpoint = workerQueueBreakpoint <= 0 ? 25 : workerQueueBreakpoint;
+
+      // Drain the queue when it reaches 90% of the max size
+      _drainSize = Math.Max(maxQueueSize / 100 * 90, 1);
       _processCallback = onProcessMessageFunc ?? throw new ArgumentNullException(nameof(onProcessMessageFunc));
       _maxWorkerTasks = maxWorkerTasks;
-      _messageQueue = new BlockingCollection<Func<RaygunMessage>>(maxQueueSize);
-      _cancelProcessingSource = new CancellationTokenSource();
-      _workerTasks = new List<Task>();
+      _messageQueue = new ConcurrentQueue<RaygunMessage>();
+      _globalCancellationSource = new CancellationTokenSource();
+      _workerTasks = new ConcurrentDictionary<Task, CancellationTokenSource>(Environment.ProcessorCount, _maxWorkerTasks);
     }
 
     public bool Enqueue(RaygunMessage message)
     {
-      return Enqueue(() => message);
-    } 
-    
-    public bool Enqueue(Func<RaygunMessage> messageFunc)
-    {
-      var itemAdded = _messageQueue.TryAdd(messageFunc);
+      if (_drainingQueue)
+      {
+        if (_messageQueue.Count >= _drainSize)
+        {
+          return false;
+        }
 
-      EnsureWorkers();
+        _drainingQueue = false;
+      }
 
-      return itemAdded;
+      if (_messageQueue.Count >= _maxQueueSize)
+      {
+        _drainingQueue = true;
+        return false;
+      }
+
+      _messageQueue.Enqueue(message);
+      AdjustWorkers();
+      return true;
     }
 
-    private void EnsureWorkers()
+    /// <summary>
+    /// This method uses the queue size to determine the number of workers that should be processing messages.
+    /// </summary>
+    private void AdjustWorkers(bool breakAfterRun = false)
     {
-      // If we are in the process of disposing or  something else has the lock,
-      // then it's going to update the workers
-      // so we can just early return, and not perform any work
+      // We only want one thread to adjust the number of workers at a time
       if (_isDisposing || !Monitor.TryEnter(_workerTaskMutex))
       {
         return;
@@ -59,19 +85,182 @@ namespace Mindscape.Raygun4Net
 
       try
       {
-        // Remove dead/faulted/finished tasks
-        _workerTasks.RemoveAll(x => x.IsCompleted);
+        // Remove any completed tasks, otherwise we might not have space to add new tasks that want to do work
+        RemoveCompletedTasks();
 
-        var numberOfWorkersToStart = _maxWorkerTasks - _workerTasks.Count;
+        // Calculate the desired number of workers based on the queue size, this is so we don't end up creating
+        // many workers that essentially do nothing, or if there's a small number of errors we don't have too many workers
+        var currentWorkers = _workerTasks.Count(x => x.Key.Status == TaskStatus.Running);
+        var desiredWorkers = CalculateDesiredWorkers(_messageQueue.Count);
 
-        for (var i = 0; i < numberOfWorkersToStart; i++)
+        if (desiredWorkers > currentWorkers)
         {
-          _workerTasks.Add(CreateWorkerTask());
+          for (var i = currentWorkers; i < desiredWorkers; i++)
+          {
+            CreateWorkerTask();
+          }
+        }
+        else if (desiredWorkers < currentWorkers)
+        {
+          RemoveExcessWorkers(currentWorkers - desiredWorkers);
+        }
+
+        if (desiredWorkers > 0 && _messageQueue.Count > 0)
+        {
+          // If we have messages to process but no workers, create a worker
+          CreateWorkerTask();
         }
       }
       finally
       {
+        // Make sure we release the mutex otherwise we'll block the next thread that wants to adjust the number of workers
         Monitor.Exit(_workerTaskMutex);
+      }
+
+      if (breakAfterRun)
+      {
+        return;
+      }
+      
+      // We only want 1 thread adjusting the workers at any given time, but there could be a race condition
+      // where the queue is empty when we release the mutex, but there are 'completed' tasks, so we need to double-check and adjust.
+      if (_messageQueue.Count > 0 && _workerTasks.All(x => x.Key.IsCompleted))
+      {
+        AdjustWorkers(true);
+      }
+    }
+
+    /// <summary>
+    /// A task may be in a completed state but not yet removed from the dictionary. This method removes any completed tasks.
+    /// Completed means the task has finished executing, whether it was successful or not. (Failed, Successful, Faulted, etc.)
+    /// </summary>
+    private void RemoveCompletedTasks()
+    {
+      var count = _workerTasks.Count;
+      var rentedArray = ArrayPool<KeyValuePair<Task, CancellationTokenSource>>.Shared.Rent(count);
+      var completedCount = 0;
+
+      foreach (var kvp in _workerTasks)
+      {
+        if (kvp.Key.IsCompleted)
+        {
+          rentedArray[completedCount++] = kvp;
+        }
+      }
+
+      for (var i = 0; i < completedCount; i++)
+      {
+        var kvp = rentedArray[i];
+        if (_workerTasks.TryRemove(kvp.Key, out var cts))
+        {
+          cts.Dispose();
+        }
+      }
+
+      ArrayPool<KeyValuePair<Task, CancellationTokenSource>>.Shared.Return(rentedArray);
+    }
+
+    /// <summary>
+    /// When the number of workers is greater than the desired number, remove the excess workers.
+    /// We do this by taking the first N workers and cancelling them.
+    /// Then we dispose of the CancellationTokenSource.
+    /// </summary>
+    /// <param name="count">Number of workers to kill off.</param>
+    private void RemoveExcessWorkers(int count)
+    {
+      var rentedArray = ArrayPool<KeyValuePair<Task, CancellationTokenSource>>.Shared.Rent(count);
+      var index = 0;
+
+      foreach (var kvp in _workerTasks)
+      {
+        if (index == count)
+        {
+          break;
+        }
+
+        rentedArray[index++] = kvp;
+      }
+
+      for (var i = 0; i < index; i++)
+      {
+        var kvp = rentedArray[i];
+
+        if (_workerTasks.TryRemove(kvp.Key, out var cts))
+        {
+          cts.Cancel();
+          cts.Dispose();
+        }
+      }
+
+      ArrayPool<KeyValuePair<Task, CancellationTokenSource>>.Shared.Return(rentedArray);
+    }
+
+    /// <summary>
+    /// Spin up a new worker task to process messages. This method is called by AdjustWorkers when the number of workers is less than the desired number.
+    /// When a task completes it will adjust the number of workers again in case the queue size has changed.
+    /// </summary>
+    private void CreateWorkerTask()
+    {
+      var cts = CancellationTokenSource.CreateLinkedTokenSource(_globalCancellationSource.Token);
+
+      var task = Task.Run(() => RaygunMessageWorker(_messageQueue, _processCallback, cts.Token), cts.Token);
+      _workerTasks[task] = cts;
+
+      // When the worker task completes, adjust the number of workers
+      task.ContinueWith(_ => AdjustWorkers(), TaskContinuationOptions.ExecuteSynchronously);
+    }
+
+    /// <summary>
+    /// Calculate the desired number of workers based on the queue size. This method is used by AdjustWorkers.
+    /// </summary>
+    private int CalculateDesiredWorkers(int queueSize)
+    {
+      // Should never have a _maxWorkerTasks of 0, but there's a couple of unit tests
+      // which use 0 to determine if messages are discarded when the queue is full
+      // so we need to allow for 0 workers to verify those tests.
+      if (queueSize == 0 || _maxWorkerTasks == 0)
+      {
+        return 0;
+      }
+
+      if (queueSize <= _workerQueueBreakpoint)
+      {
+        return 1;
+      }
+
+      return Math.Min((queueSize + _workerQueueBreakpoint - 1) / _workerQueueBreakpoint, _maxWorkerTasks);
+    }
+
+    /// <summary>
+    /// Actual task run by the worker. This method will take a message from the queue and process it.
+    /// </summary>
+    private static async Task RaygunMessageWorker(ConcurrentQueue<RaygunMessage> messageQueue,
+                                                  Func<RaygunMessage, CancellationToken, Task> callback,
+                                                  CancellationToken cancellationToken)
+    {
+      try
+      {
+        while (!cancellationToken.IsCancellationRequested && messageQueue.TryDequeue(out var message))
+        {
+          try
+          {
+            await callback(message, cancellationToken);
+          }
+          catch (InvalidOperationException)
+          {
+            break;
+          }
+        }
+      }
+      catch (Exception cancelledEx) when (cancelledEx is ThreadAbortException
+                                                         or OperationCanceledException
+                                                         or TaskCanceledException)
+      {
+        // Task was cancelled, this is expected behavior
+      }
+      catch (Exception ex)
+      {
+        Debug.WriteLine($"Exception in queue worker: {ex}");
       }
     }
 
@@ -84,46 +273,30 @@ namespace Mindscape.Raygun4Net
 
       _isDisposing = true;
 
-      _messageQueue.CompleteAdding();
-      _cancelProcessingSource.Cancel();
-      _messageQueue.Dispose();
-
-      // Wait a few seconds for the workers to finish gracefully
-      Task.WaitAll(_workerTasks.ToArray(), TimeSpan.FromSeconds(2));
-    }
-
-    private Task CreateWorkerTask()
-    {
-      var workerTask = Task.Factory
-        .StartNew(() => { RaygunMessageWorker(_messageQueue, _processCallback, _cancelProcessingSource.Token); }, TaskCreationOptions.LongRunning);
-
-      // When a worker finishes ensure that a new one is is created if required
-      workerTask.ContinueWith(x => { EnsureWorkers(); });
-
-      return workerTask;
-    }
-
-    private static void RaygunMessageWorker(
-      BlockingCollection<Func<RaygunMessage>> messageQueue,
-      Action<RaygunMessage> callback, 
-      CancellationToken cancellationToken)
-    {
       try
       {
-        foreach (var messageFunc in messageQueue.GetConsumingEnumerable(cancellationToken))
+        foreach (var kvp in _workerTasks)
         {
-          callback(messageFunc());
+          if (_workerTasks.TryRemove(kvp.Key, out var cts))
+          {
+            if (!cts.IsCancellationRequested)
+            {
+              cts.Cancel();
+            }
+
+            cts.Dispose();
+          }
         }
-      }
-      catch (Exception cancelledEx) when (cancelledEx is ThreadAbortException ||
-                                          cancelledEx is OperationCanceledException ||
-                                          cancelledEx is TaskCanceledException)
-      {
-        // Cancellation was requested, so it's fine
+
+        _globalCancellationSource.Cancel();
+
+        Task.WaitAll(_workerTasks.Keys.ToArray(), TimeSpan.FromSeconds(2));
+
+        _globalCancellationSource.Dispose();
       }
       catch (Exception ex)
       {
-        Debug.WriteLine("Exception in queue worker {0}: {1}", Task.CurrentId, ex);
+        Debug.WriteLine($"Exception in ThrottledBackgroundMessageProcessor.Dispose: {ex}");
       }
     }
   }


### PR DESCRIPTION
This PR ports the solution implemented in `Mindscape.Raygun4Net.NetCore.Common\ThrottledBackgroundMessageProcessor.cs` to `Mindscape.Raygun4Net4\ThrottledBackgroundMessageProcessor.cs`.

In order to support `Raygun4Net4`, it has been adapted to support the existing `Send` and `Enqueue` method. As well, a setting for the breakpoint at which new worker threads are added as been created.
The unit tests in `Mindscape.Raygun4Net4.Tests\ThrottledBackgroundMessageProcessorTests.cs` have been adapted, as well added the new test `Things_Throwing_Many` copied and adapted from the `NetCore` project.

The change passes CI checks in TeamCity, and has been tested using the project in https://github.com/MindscapeHQ/sample-apps/tree/master/src/FullFramework/Net462WebApplication

Fixes #558 