### PR TITLE
Microsoft.AspNetCore.Http ver 2.3.0

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[Microsoft.AspNetCore.Http ver. 2.2.2](https://www.nuget.org/packages/Microsoft.AspNetCore.Http/2.2.2) is obsolete.