### PR TITLE
Use IsRawDataIgnored setting to control request buffering

### DIFF
--- a/Mindscape.Raygun4Net.AspNetCore/RaygunMiddleware.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunMiddleware.cs
@@ -30,7 +30,12 @@ public class RaygunMiddleware
 
   public async Task Invoke(HttpContext httpContext)
   {
-    httpContext.Request.EnableBuffering();
+    // Only enable buffering if we're going to capture the request body
+    // IsRawDataIgnored = true means we won't capture raw data, so no need to buffer
+    if (!_settings.IsRawDataIgnored)
+    {
+      httpContext.Request.EnableBuffering();
+    }
     
     if (RaygunBreadcrumbs.Storage is IContextAwareStorage storage)
     {


### PR DESCRIPTION
## Problem

The `RaygunMiddleware` currently calls `httpContext.Request.EnableBuffering()` for **every request**, regardless of whether an exception occurs or whether the request body will even be captured:

```csharp
public async Task Invoke(HttpContext httpContext)
{
    httpContext.Request.EnableBuffering();  // Called on EVERY request
    // ...
}
```

This causes unnecessary overhead in high-throughput applications because:

1. **Memory allocation**: `EnableBuffering()` allocates buffers or uses disk-based buffering for large request bodies
2. **Read pipeline overhead**: Adds overhead to read pipelines, especially for streaming or large uploads
3. **Wasted resources**: When `IsRawDataIgnored = true`, we won't capture the request body anyway, so buffering is pointless

## Solution

Use the existing `IsRawDataIgnored` setting to control whether buffering is enabled:

```csharp
public async Task Invoke(HttpContext httpContext)
{
    // Only enable buffering if we're going to capture the request body
    // IsRawDataIgnored = true means we won't capture raw data, so no need to buffer
    if (!_settings.IsRawDataIgnored)
    {
        httpContext.Request.EnableBuffering();
    }
    // ...
}
```

This is a logical fit because:
- `IsRawDataIgnored = false` (default): We want to capture request bodies → enable buffering
- `IsRawDataIgnored = true`: We're ignoring request bodies → no need to buffer

## Usage

To disable buffering for better performance:

**appsettings.json:**
```json
"RaygunSettings": {
  "ApiKey": "YOUR_API_KEY",
  "IsRawDataIgnored": true
}
```

**Or in code:**
```csharp
builder.Services.AddRaygun(builder.Configuration, settings => 
{
    settings.IsRawDataIgnored = true;
});
```

## Backward Compatibility

- Default value of `IsRawDataIgnored` is `false`, so buffering remains enabled by default
- Existing applications will work without any changes
- No new settings introduced - uses existing setting with logical behavior

## Tests Added

- `WhenIsRawDataIgnoredIsFalse_RequestBodyShouldBeBuffered` - Verifies buffering works when raw data is captured
- `WhenIsRawDataIgnoredIsTrue_RequestBodyStreamShouldNotBeBuffered` - Verifies stream is not seekable when raw data is ignored
- `WhenIsRawDataIgnoredIsDefault_ShouldBeFalse` - Verifies default is `false` for backward compatibility