### PR TITLE
fix: Use fully-qualified type name for MarshalManagedExceptionMode DynamicDependency

### DIFF
--- a/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
+++ b/Mindscape.Raygun4Net.NetCore.Common/Platforms/ApplePlatform.cs
@@ -18,9 +18,9 @@ namespace Mindscape.Raygun4Net.Platforms
     // from being trimmed by the compiler.
     // Not supported in netstandard2.0.
     [DynamicDependency("MarshalManagedException", "ObjCRuntime.Runtime", "Microsoft.iOS")]
-    [DynamicDependency("MarshalManagedExceptionMode", "ObjCRuntime", "Microsoft.iOS")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields, "ObjCRuntime.MarshalManagedExceptionMode", "Microsoft.iOS")]
     [DynamicDependency("MarshalManagedException", "ObjCRuntime.Runtime", "Microsoft.MacCatalyst")]
-    [DynamicDependency("MarshalManagedExceptionMode", "ObjCRuntime", "Microsoft.MacCatalyst")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields, "ObjCRuntime.MarshalManagedExceptionMode", "Microsoft.MacCatalyst")]
     [UnconditionalSuppressMessage("Trimming", "IL2035",
       Justification = "Platform assemblies are conditionally loaded at runtime; missing assemblies are expected on non-target platforms.")]
 #endif


### PR DESCRIPTION
## Problem

The `DynamicDependency` attributes for `MarshalManagedExceptionMode` in `ApplePlatform.cs` used `"ObjCRuntime"` as the type name instead of the fully-qualified `"ObjCRuntime.MarshalManagedExceptionMode"`.

This caused **IL2036** warnings (`Unresolved type 'ObjCRuntime' in 'DynamicDependencyAttribute'`) during trimmed iOS/MacCatalyst builds, and risked the enum type being stripped by the trimmer — which would silently break crash capture at runtime.

## Fix

Changed the type parameter in the `DynamicDependency` attributes from `"ObjCRuntime"` to `"ObjCRuntime.MarshalManagedExceptionMode"` for both `Microsoft.iOS` and `Microsoft.MacCatalyst`, matching the actual type resolved at runtime on line 54:

```csharp
var enumType = activeAssembly.GetType("ObjCRuntime.MarshalManagedExceptionMode");
```

## Verification

Clean Release build of an iOS example app (`net10.0-ios` with `TrimMode=full`) confirms IL2036 is eliminated.

Related to #576