### PR TITLE
docs: add v11.2.6 changelog

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,10 @@
 # Full Change Log for Raygun4Net.* packages
 
+### v11.2.6
+- Fix: Restore `netstandard2.0` dependency resolution for Mindscape.Raygun4Net.AspNetCore
+  - Replace the unavailable `Microsoft.Extensions.Options.ConfigurationExtensions` v2.3.0 dependency with `Microsoft.Extensions.Configuration.Binder` v8.0.0
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/580
+
 ### v11.2.5
 - Performance: Resolve Raygun Assembly Version once instead of per message
   - See: https://github.com/MindscapeHQ/raygun4net/pull/556


### PR DESCRIPTION
## Summary

- add the v11.2.6 changelog section
- document the ASP.NET Core netstandard2.0 dependency fix merged in PR #580

## Why

Microsoft.Extensions.Options.ConfigurationExtensions v2.3.0 does not exist on NuGet, which broke dependency resolution. PR #580 replaced it with the narrower Microsoft.Extensions.Configuration.Binder v8.0.0 dependency.

## Impact

Documents the fix for the v11.2.6 release.

## Validation

- git diff --check
- documentation-only change; no build required