### PR TITLE
feat: add opt-in request IP address masking

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -2,10 +2,11 @@
 
 ### vTODO
 - Feature: Opt-in request IP address masking (`IsRequestIpAddressMasked`)
-  - Masks `RaygunRequestMessage.IPAddress` to IPv4 `/24` and IPv6 `/48` prefixes (ports retained)
+  - Masks IPv4 and IPv4-mapped IPv6 addresses to the embedded IPv4 `/24`, and native IPv6 addresses to `/48` (ports retained)
+  - Excludes known client-IP forwarding headers and server variables from request metadata while masking is enabled
   - Supported on AspNetCore, MVC/Net4, and WebApi providers; disabled by default
   - Classic Net4/WebApi IP extraction now accepts IPv6 (including bracketed forms) from X-Forwarded-For / REMOTE_ADDR
-  - XFF/REMOTE_ADDR acceptance uses strict port validation; masking still best-effort redacts the host when a port suffix is malformed
+  - XFF/REMOTE_ADDR acceptance requires canonical four-octet IPv4 values and strict port validation; masking still best-effort redacts the host when a port suffix is malformed
   - AspNetCore: unmasked IPv6+port keeps the historical `addr:port` shape; masked IPv6+port uses unambiguous `[addr]:port`
   - See: https://github.com/MindscapeHQ/raygun4net/pull/583
 

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -7,7 +7,7 @@
   - Classic Net4/WebApi IP extraction now accepts IPv6 (including bracketed forms) from X-Forwarded-For / REMOTE_ADDR
   - XFF/REMOTE_ADDR acceptance uses strict port validation; masking still best-effort redacts the host when a port suffix is malformed
   - AspNetCore: unmasked IPv6+port keeps the historical `addr:port` shape; masked IPv6+port uses unambiguous `[addr]:port`
-  - See: TODO https://github.com/MindscapeHQ/raygun4net/pull/TODO
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/583
 
 ### v11.2.6
 - Fix: Restore `netstandard2.0` dependency resolution for Mindscape.Raygun4Net.AspNetCore

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,14 @@
 # Full Change Log for Raygun4Net.* packages
 
+### vTODO
+- Feature: Opt-in request IP address masking (`IsRequestIpAddressMasked`)
+  - Masks `RaygunRequestMessage.IPAddress` to IPv4 `/24` and IPv6 `/48` prefixes (ports retained)
+  - Supported on AspNetCore, MVC/Net4, and WebApi providers; disabled by default
+  - Classic Net4/WebApi IP extraction now accepts IPv6 (including bracketed forms) from X-Forwarded-For / REMOTE_ADDR
+  - XFF/REMOTE_ADDR acceptance uses strict port validation; masking still best-effort redacts the host when a port suffix is malformed
+  - AspNetCore: unmasked IPv6+port keeps the historical `addr:port` shape; masked IPv6+port uses unambiguous `[addr]:port`
+  - See: TODO https://github.com/MindscapeHQ/raygun4net/pull/TODO
+
 ### v11.2.6
 - Fix: Restore `netstandard2.0` dependency resolution for Mindscape.Raygun4Net.AspNetCore
   - Replace the unavailable `Microsoft.Extensions.Options.ConfigurationExtensions` v2.3.0 dependency with `Microsoft.Extensions.Configuration.Binder` v8.0.0

--- a/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
@@ -297,7 +297,9 @@ namespace Mindscape.Raygun4Net.AspNetCore.Builders
       {
         foreach (var header in request.Headers)
         {
-          if (IsIgnored(header.Key, options.IgnoreHeaderNames) || IsIgnored(header.Key, options.IgnoreSensitiveFieldNames))
+          if (IsIgnored(header.Key, options.IgnoreHeaderNames) ||
+              IsIgnored(header.Key, options.IgnoreSensitiveFieldNames) ||
+              (options.IsRequestIpAddressMasked && IpAddressMasker.IsClientIpAddressHeader(header.Key)))
           {
             continue;
           }

--- a/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/Builders/RaygunAspNetCoreRequestMessageBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -33,7 +34,7 @@ namespace Mindscape.Raygun4Net.AspNetCore.Builders
         HostName    = request.Host.Value,
         Url         = request.GetDisplayUrl(),
         HttpMethod  = request.Method,
-        IPAddress   = GetIpAddress(context.Connection),
+        IPAddress   = GetIpAddress(context.Connection, options.IsRequestIpAddressMasked),
         QueryString = GetQueryString(request, options),
         Cookies     = GetCookies(request, options),
         RawData     = GetRawData(request, options),
@@ -44,7 +45,7 @@ namespace Mindscape.Raygun4Net.AspNetCore.Builders
       return message;
     }
 
-    private static string GetIpAddress(ConnectionInfo connection)
+    private static string GetIpAddress(ConnectionInfo connection, bool isRequestIpAddressMasked)
     {
       var ip = connection.RemoteIpAddress ?? connection.LocalIpAddress;
 
@@ -54,6 +55,18 @@ namespace Mindscape.Raygun4Net.AspNetCore.Builders
       }
 
       int? port = connection.RemotePort == 0 ? connection.LocalPort : connection.RemotePort;
+
+      if (isRequestIpAddressMasked)
+      {
+        ip = IpAddressMasker.Mask(ip);
+
+        // Bracket IPv6 only on the masked path so unmasked output stays compatible with
+        // the historical "addr:port" format when masking is disabled.
+        if (port != 0 && ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+          return $"[{ip}]:{port.Value}";
+        }
+      }
 
       if (port != 0)
       {

--- a/Mindscape.Raygun4Net.AspNetCore/IRaygunHttpSettings.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/IRaygunHttpSettings.cs
@@ -15,6 +15,7 @@ internal interface IRaygunHttpSettings
     
   bool IsRawDataIgnored { get; }
   bool IsRawDataIgnoredWhenFilteringFailed { get; }
+  bool IsRequestIpAddressMasked { get; }
   bool UseXmlRawDataFilter { get; }
   bool UseKeyValuePairRawDataFilter { get; }
 }

--- a/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
+++ b/Mindscape.Raygun4Net.AspNetCore/Mindscape.Raygun4Net.AspNetCore.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\IpAddressMasker.cs" Link="IpAddressMasker.cs" />
     <Compile Include="..\Mindscape.Raygun4Net.Core\Filters\IRaygunDataFilter.cs" Link="Filters\IRaygunDataFilter.cs" />
     <Compile Include="..\Mindscape.Raygun4Net.Core\Filters\RaygunXmlDataFilter.cs" Link="Filters\RaygunXmlDataFilter.cs" />
     <Compile Include="..\Mindscape.Raygun4Net.Core\Filters\RaygunKeyValuePairDataFilter.cs" Link="Filters\RaygunKeyValuePairDataFilter.cs" />

--- a/Mindscape.Raygun4Net.AspNetCore/README.md
+++ b/Mindscape.Raygun4Net.AspNetCore/README.md
@@ -169,7 +169,7 @@ Examples below are shown in appsettings.json format.
 Mask request IP addresses
 -------------------------
 
-Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses and the embedded IPv4 portion of IPv4-mapped IPv6 addresses to a `/24` prefix, and native IPv6 addresses to a `/48` prefix, while retaining any port:
 
 ```json
 "RaygunSettings": {
@@ -178,7 +178,7 @@ Request IP address masking is disabled by default. Enable it to mask IPv4 addres
 }
 ```
 
-This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers, configure the relevant ignore settings as well.
+When enabled, Raygun also excludes known client-IP forwarding headers, such as `X-Forwarded-For` and `Forwarded`, from request metadata. Custom headers and arbitrary request fields are not scanned; configure the relevant ignore settings for any additional application-specific metadata.
 
 Replace unseekable request streams
 ----------------------------------

--- a/Mindscape.Raygun4Net.AspNetCore/README.md
+++ b/Mindscape.Raygun4Net.AspNetCore/README.md
@@ -166,6 +166,20 @@ services.AddRaygun(settings =>
 
 Examples below are shown in appsettings.json format.
 
+Mask request IP addresses
+-------------------------
+
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+
+```json
+"RaygunSettings": {
+  "ApiKey": "YOUR_APP_API_KEY",
+  "IsRequestIpAddressMasked": true
+}
+```
+
+This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers, configure the relevant ignore settings as well.
+
 Replace unseekable request streams
 ----------------------------------
 

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunSettings.cs
@@ -13,6 +13,12 @@ public class RaygunSettings : RaygunSettingsBase, IRaygunHttpSettings
 
   public bool ExcludeErrorsFromLocal { get; set; }
 
+  /// <summary>
+  /// Gets or sets whether request IP addresses are masked before being sent.
+  /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+  /// </summary>
+  public bool IsRequestIpAddressMasked { get; set; }
+
   public List<string> IgnoreSensitiveFieldNames { get; set; } = new();
 
   public List<string> IgnoreQueryParameterNames { get; set; } = new();

--- a/Mindscape.Raygun4Net.AspNetCore/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.AspNetCore/RaygunSettings.cs
@@ -15,7 +15,9 @@ public class RaygunSettings : RaygunSettingsBase, IRaygunHttpSettings
 
   /// <summary>
   /// Gets or sets whether request IP addresses are masked before being sent.
-  /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+  /// IPv4 and IPv4-mapped IPv6 addresses are masked to the embedded IPv4 /24 prefix;
+  /// native IPv6 addresses are masked to a /48 prefix. Known client-IP headers are excluded
+  /// from request metadata while masking is enabled.
   /// </summary>
   public bool IsRequestIpAddressMasked { get; set; }
 

--- a/Mindscape.Raygun4Net.Core/RaygunRequestMessageOptions.cs
+++ b/Mindscape.Raygun4Net.Core/RaygunRequestMessageOptions.cs
@@ -13,6 +13,7 @@ namespace Mindscape.Raygun4Net
     private readonly List<string> _ignoreServerVariableNames = new List<string>();
     private bool _isRawDataIgnored;
     private bool _isRawDataIgnoredWhenFilteringFailed;
+    private bool _isRequestIpAddressMasked;
     private bool _useXmlRawDataFilter;
     private bool _useKeyValuePairRawDataFilter;
 
@@ -47,6 +48,16 @@ namespace Mindscape.Raygun4Net
     {
       get { return _isRawDataIgnoredWhenFilteringFailed; }
       set { _isRawDataIgnoredWhenFilteringFailed = value; }
+    }
+
+    /// <summary>
+    /// Gets or sets whether request IP addresses are masked before being sent.
+    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// </summary>
+    public bool IsRequestIpAddressMasked
+    {
+      get { return _isRequestIpAddressMasked; }
+      set { _isRequestIpAddressMasked = value; }
     }
 
     public bool UseXmlRawDataFilter

--- a/Mindscape.Raygun4Net.Core/RaygunRequestMessageOptions.cs
+++ b/Mindscape.Raygun4Net.Core/RaygunRequestMessageOptions.cs
@@ -52,7 +52,9 @@ namespace Mindscape.Raygun4Net
 
     /// <summary>
     /// Gets or sets whether request IP addresses are masked before being sent.
-    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// IPv4 and IPv4-mapped IPv6 addresses are masked to the embedded IPv4 /24 prefix;
+    /// native IPv6 addresses are masked to a /48 prefix. Known client-IP headers and server
+    /// variables are excluded from request metadata while masking is enabled.
     /// </summary>
     public bool IsRequestIpAddressMasked
     {

--- a/Mindscape.Raygun4Net.Core/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.Core/RaygunSettings.cs
@@ -182,7 +182,9 @@ namespace Mindscape.Raygun4Net
 
     /// <summary>
     /// Gets or sets whether request IP addresses are masked before being sent.
-    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// IPv4 and IPv4-mapped IPv6 addresses are masked to the embedded IPv4 /24 prefix;
+    /// native IPv6 addresses are masked to a /48 prefix. Known client-IP headers and server
+    /// variables are excluded from request metadata while masking is enabled.
     /// </summary>
     [ConfigurationProperty("isRequestIpAddressMasked", IsRequired = false, DefaultValue = false)]
     public bool IsRequestIpAddressMasked

--- a/Mindscape.Raygun4Net.Core/RaygunSettings.cs
+++ b/Mindscape.Raygun4Net.Core/RaygunSettings.cs
@@ -180,6 +180,17 @@ namespace Mindscape.Raygun4Net
       set { this["isRawDataIgnoredWhenFilteringFailed"] = value; }
     }
 
+    /// <summary>
+    /// Gets or sets whether request IP addresses are masked before being sent.
+    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// </summary>
+    [ConfigurationProperty("isRequestIpAddressMasked", IsRequired = false, DefaultValue = false)]
+    public bool IsRequestIpAddressMasked
+    {
+      get { return (bool)this["isRequestIpAddressMasked"]; }
+      set { this["isRequestIpAddressMasked"] = value; }
+    }
+
     [ConfigurationProperty("isResponseContentIgnored", IsRequired = false, DefaultValue = true)]
     public bool IsResponseContentIgnored
     {

--- a/Mindscape.Raygun4Net.Mvc/README.md
+++ b/Mindscape.Raygun4Net.Mvc/README.md
@@ -105,13 +105,13 @@ i.e. A way to prevent local debug/development from notifying Raygun without havi
 Mask request IP addresses
 -------------------------
 
-Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses and the embedded IPv4 portion of IPv4-mapped IPv6 addresses to a `/24` prefix, and native IPv6 addresses to a `/48` prefix, while retaining any port:
 
 ```
 <RaygunSettings apikey="YOUR_APP_API_KEY" isRequestIpAddressMasked="true" />
 ```
 
-This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers or server variables, configure the relevant ignore settings as well.
+When enabled, Raygun also excludes known client-IP forwarding headers and server variables, such as `X-Forwarded-For`, `Forwarded`, and `REMOTE_ADDR`, from request metadata. Custom headers and arbitrary request fields are not scanned; configure the relevant ignore settings for any additional application-specific metadata.
 
 Remove sensitive request data
 -----------------------------

--- a/Mindscape.Raygun4Net.Mvc/README.md
+++ b/Mindscape.Raygun4Net.Mvc/README.md
@@ -102,6 +102,17 @@ i.e. A way to prevent local debug/development from notifying Raygun without havi
 
 <RaygunSettings apikey="YOUR_APP_API_KEY" excludeErrorsFromLocal="true" />
 
+Mask request IP addresses
+-------------------------
+
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+
+```
+<RaygunSettings apikey="YOUR_APP_API_KEY" isRequestIpAddressMasked="true" />
+```
+
+This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers or server variables, configure the relevant ignore settings as well.
+
 Remove sensitive request data
 -----------------------------
 

--- a/Mindscape.Raygun4Net.Tests/RaygunRequestMessageOptionsTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunRequestMessageOptionsTests.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+
+namespace Mindscape.Raygun4Net.Tests
+{
+  [TestFixture]
+  public class RaygunRequestMessageOptionsTests
+  {
+    [Test]
+    public void RequestIpAddressMaskingIsDisabledByDefault()
+    {
+      var options = new RaygunRequestMessageOptions();
+
+      Assert.That(options.IsRequestIpAddressMasked, Is.False);
+    }
+
+    [Test]
+    public void RequestIpAddressMaskingCanBeEnabled()
+    {
+      var options = new RaygunRequestMessageOptions
+      {
+        IsRequestIpAddressMasked = true
+      };
+
+      Assert.That(options.IsRequestIpAddressMasked, Is.True);
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.Tests/RaygunRequestMessageTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunRequestMessageTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Web;
+using System.Web.Hosting;
 using Mindscape.Raygun4Net.Builders;
 using Mindscape.Raygun4Net.Messages;
 using NUnit.Framework;
@@ -46,6 +48,60 @@ namespace Mindscape.Raygun4Net.Tests
       var message = RaygunRequestMessageBuilder.Build(_defaultRequest, null);
 
       Assert.That(message.HttpMethod, Is.EqualTo("GET"));
+    }
+
+    [TestCase("192.168.12.123", false, "192.168.12.123")]
+    [TestCase("192.168.12.123", true, "192.168.12.0")]
+    [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", false, "2001:db8:1234:5678:9abc:def0:1234:5678")]
+    [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", true, "2001:db8:1234::")]
+    public void RequestIpAddressMasking(string address, bool isMasked, string expected)
+    {
+      var context = new HttpContext(new TestWorkerRequest(address));
+      var options = new RaygunRequestMessageOptions
+      {
+        IsRequestIpAddressMasked = isMasked
+      };
+
+      var message = RaygunRequestMessageBuilder.Build(context.Request, options);
+
+      Assert.That(message.IPAddress, Is.EqualTo(expected));
+    }
+
+    [TestCase("192.168.12.123", false, "192.168.12.123")]
+    [TestCase("192.168.12.123", true, "192.168.12.0")]
+    [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", false, "2001:db8:1234:5678:9abc:def0:1234:5678")]
+    [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", true, "2001:db8:1234::")]
+    [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]:443", true, "[2001:db8:1234::]:443")]
+    [TestCase("192.168.12.123:8080", true, "192.168.12.0:8080")]
+    public void RequestIpAddressFromXForwardedFor(string xForwardedFor, bool isMasked, string expected)
+    {
+      // REMOTE_ADDR is a different address so we prove XFF is preferred when valid (including IPv6).
+      var context = new HttpContext(new TestWorkerRequest("10.0.0.1", xForwardedFor));
+      var options = new RaygunRequestMessageOptions
+      {
+        IsRequestIpAddressMasked = isMasked
+      };
+
+      var message = RaygunRequestMessageBuilder.Build(context.Request, options);
+
+      Assert.That(message.IPAddress, Is.EqualTo(expected));
+    }
+
+    [TestCase("192.168.12.123:65536")]
+    [TestCase("192.168.12.123:abc")]
+    [TestCase("192.168.12.123:")]
+    public void InvalidXForwardedForPortFallsBackToRemoteAddr(string xForwardedFor)
+    {
+      // Strict validation rejects invalid ports so XFF cannot override REMOTE_ADDR.
+      var context = new HttpContext(new TestWorkerRequest("10.0.0.1", xForwardedFor));
+      var options = new RaygunRequestMessageOptions
+      {
+        IsRequestIpAddressMasked = true
+      };
+
+      var message = RaygunRequestMessageBuilder.Build(context.Request, options);
+
+      Assert.That(message.IPAddress, Is.EqualTo("10.0.0.0"));
     }
 
     [Test]
@@ -421,6 +477,34 @@ namespace Mindscape.Raygun4Net.Tests
       rawData = FakeRaygunRequestMessageBuilder.ExposeStripIgnoredFormData(rawData, ignored);
 
       Assert.That("------WebKitFormBoundarye64VBkpu4PoxFbpl Content-Disposition: form-data;  ------WebKitFormBoundarye64VBkpu4PoxFbpl--", Is.EqualTo(rawData));
+    }
+
+    private sealed class TestWorkerRequest : SimpleWorkerRequest
+    {
+      private readonly string _remoteAddress;
+      private readonly string _xForwardedFor;
+
+      public TestWorkerRequest(string remoteAddress, string xForwardedFor = null)
+        : base("/", string.Empty, new StringWriter())
+      {
+        _remoteAddress = remoteAddress;
+        _xForwardedFor = xForwardedFor;
+      }
+
+      public override string GetRemoteAddress()
+      {
+        return _remoteAddress;
+      }
+
+      public override string GetServerVariable(string name)
+      {
+        if (name == "HTTP_X_FORWARDED_FOR" && _xForwardedFor != null)
+        {
+          return _xForwardedFor;
+        }
+
+        return base.GetServerVariable(name);
+      }
     }
   }
 }

--- a/Mindscape.Raygun4Net.Tests/RaygunRequestMessageTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunRequestMessageTests.cs
@@ -105,6 +105,37 @@ namespace Mindscape.Raygun4Net.Tests
     }
 
     [Test]
+    public void MaskingRemovesExactClientIpFromKnownRequestMetadataAndSerializedPayload()
+    {
+      const string exactAddress = "192.168.12.123";
+      var context = new HttpContext(new TestWorkerRequest(exactAddress, exactAddress));
+
+      var message = RaygunRequestMessageBuilder.Build(context.Request, new RaygunRequestMessageOptions
+      {
+        IsRequestIpAddressMasked = true
+      });
+
+      Assert.That(message.IPAddress, Is.EqualTo("192.168.12.0"));
+      Assert.That(message.Data.Contains("REMOTE_ADDR"), Is.False);
+      Assert.That(message.Data.Contains("HTTP_X_FORWARDED_FOR"), Is.False);
+      Assert.That(message.Headers.Contains("X-Forwarded-For"), Is.False);
+      Assert.That(SimpleJson.SerializeObject(message), Does.Not.Contain(exactAddress));
+    }
+
+    [Test]
+    public void DisabledMaskingRetainsKnownClientIpRequestMetadata()
+    {
+      const string exactAddress = "192.168.12.123";
+      var context = new HttpContext(new TestWorkerRequest(exactAddress, exactAddress));
+
+      var message = RaygunRequestMessageBuilder.Build(context.Request, new RaygunRequestMessageOptions());
+
+      Assert.That(message.Data["REMOTE_ADDR"], Is.EqualTo(exactAddress));
+      Assert.That(message.Data["HTTP_X_FORWARDED_FOR"], Is.EqualTo(exactAddress));
+      Assert.That(message.Headers["X-Forwarded-For"], Is.EqualTo(exactAddress));
+    }
+
+    [Test]
     public void QueryStringTest()
     {
       var request = new HttpRequest("test", "http://google.com", "test=test");
@@ -504,6 +535,19 @@ namespace Mindscape.Raygun4Net.Tests
         }
 
         return base.GetServerVariable(name);
+      }
+
+      public override string[][] GetUnknownRequestHeaders()
+      {
+        if (_xForwardedFor != null)
+        {
+          return new[]
+          {
+            new[] { "X-Forwarded-For", _xForwardedFor }
+          };
+        }
+
+        return base.GetUnknownRequestHeaders();
       }
     }
   }

--- a/Mindscape.Raygun4Net.Tests/RaygunSettingsTests.cs
+++ b/Mindscape.Raygun4Net.Tests/RaygunSettingsTests.cs
@@ -72,6 +72,12 @@ namespace Mindscape.Raygun4Net.Tests
     }
 
     [Test]
+    public void IsRequestIpAddressMasked_FalseByDefault()
+    {
+      Assert.That(RaygunSettings.Settings.IsRequestIpAddressMasked, Is.False);
+    }
+
+    [Test]
     public void ApplicationVersion_EmptyByDefault()
     {
       Assert.That(RaygunSettings.Settings.ApplicationVersion, Is.Empty);

--- a/Mindscape.Raygun4Net.WebApi.Tests/Model/FakeRaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/Model/FakeRaygunWebApiClient.cs
@@ -1,4 +1,5 @@
-﻿using Mindscape.Raygun4Net.Messages;
+﻿using Mindscape.Raygun4Net;
+using Mindscape.Raygun4Net.Messages;
 using System;
 using System.Collections.Generic;
 
@@ -6,6 +7,20 @@ namespace Mindscape.Raygun4Net.WebApi.Tests.Model
 {
   public class FakeRaygunWebApiClient : RaygunWebApiClient
   {
+    public FakeRaygunWebApiClient()
+    {
+    }
+
+    public FakeRaygunWebApiClient(string apiKey)
+      : base(apiKey)
+    {
+    }
+
+    public RaygunRequestMessageOptions ExposeRequestMessageOptions
+    {
+      get { return _requestMessageOptions; }
+    }
+
     public bool ExposeCanSend(RaygunMessage message)
     {
       return CanSend(message);

--- a/Mindscape.Raygun4Net.WebApi.Tests/RaygunRequestMessageBuilderTests.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/RaygunRequestMessageBuilderTests.cs
@@ -1,5 +1,7 @@
 ﻿using NUnit.Framework;
 using System.Collections.Generic;
+using System.Dynamic;
+using System.Net.Http;
 using Mindscape.Raygun4Net.WebApi.Builders;
 
 namespace Mindscape.Raygun4Net.WebApi.Tests
@@ -7,6 +9,29 @@ namespace Mindscape.Raygun4Net.WebApi.Tests
   [TestFixture]
   public class RaygunRequestMessageBuilderTests
   {
+    [TestCase("192.168.12.123", false, "192.168.12.123")]
+    [TestCase("192.168.12.123", true, "192.168.12.0")]
+    [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", true, "2001:db8:1234::")]
+    public void BuildAppliesConfiguredIpAddressMasking(string address, bool isMasked, string expected)
+    {
+      using (var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com"))
+      {
+        request.Content = new StringContent(string.Empty);
+        dynamic context = new ExpandoObject();
+        context.Request = new ExpandoObject();
+        context.Request.UserHostAddress = address;
+        request.Properties["MS_HttpContext"] = context;
+        var options = new RaygunRequestMessageOptions
+        {
+          IsRequestIpAddressMasked = isMasked
+        };
+
+        var message = RaygunWebApiRequestMessageBuilder.Build(request, options);
+
+        Assert.That(message.IPAddress, Is.EqualTo(expected));
+      }
+    }
+
     [Test]
     public void RawDataRemainsUnchangedWhenParsingFails()
     {

--- a/Mindscape.Raygun4Net.WebApi.Tests/RaygunRequestMessageBuilderTests.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/RaygunRequestMessageBuilderTests.cs
@@ -33,6 +33,49 @@ namespace Mindscape.Raygun4Net.WebApi.Tests
     }
 
     [Test]
+    public void BuildRemovesKnownClientIpHeadersWhenMaskingIsEnabled()
+    {
+      using (var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com"))
+      {
+        request.Content = new StringContent(string.Empty);
+        request.Headers.TryAddWithoutValidation("X-Forwarded-For", "192.168.12.123");
+        request.Headers.TryAddWithoutValidation("Forwarded", "for=192.168.12.123");
+        request.Headers.TryAddWithoutValidation("X-Correlation-ID", "correlation-value");
+        dynamic context = new ExpandoObject();
+        context.Request = new ExpandoObject();
+        context.Request.UserHostAddress = "192.168.12.123";
+        request.Properties["MS_HttpContext"] = context;
+
+        var message = RaygunWebApiRequestMessageBuilder.Build(request, new RaygunRequestMessageOptions
+        {
+          IsRequestIpAddressMasked = true
+        });
+
+        Assert.That(message.Headers.Contains("X-Forwarded-For"), Is.False);
+        Assert.That(message.Headers.Contains("Forwarded"), Is.False);
+        Assert.That(message.Headers["X-Correlation-ID"], Is.EqualTo("correlation-value"));
+      }
+    }
+
+    [Test]
+    public void BuildRetainsClientIpHeadersWhenMaskingIsDisabled()
+    {
+      using (var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com"))
+      {
+        request.Content = new StringContent(string.Empty);
+        request.Headers.TryAddWithoutValidation("X-Forwarded-For", "192.168.12.123");
+        dynamic context = new ExpandoObject();
+        context.Request = new ExpandoObject();
+        context.Request.UserHostAddress = "192.168.12.123";
+        request.Properties["MS_HttpContext"] = context;
+
+        var message = RaygunWebApiRequestMessageBuilder.Build(request, new RaygunRequestMessageOptions());
+
+        Assert.That(message.Headers["X-Forwarded-For"], Is.EqualTo("192.168.12.123"));
+      }
+    }
+
+    [Test]
     public void RawDataRemainsUnchangedWhenParsingFails()
     {
       var rawData = "I am unchanged!";

--- a/Mindscape.Raygun4Net.WebApi.Tests/RaygunWebApiClientTests.cs
+++ b/Mindscape.Raygun4Net.WebApi.Tests/RaygunWebApiClientTests.cs
@@ -22,6 +22,57 @@ namespace Mindscape.Raygun4Net.WebApi.Tests
     }
 
     [Test]
+    public void RequestIpAddressMaskingCanBeConfigured()
+    {
+      _client.IsRequestIpAddressMasked = true;
+
+      Assert.That(_client.IsRequestIpAddressMasked, Is.True);
+    }
+
+    [Test]
+    public void RequestIpAddressMaskingIsCopiedFromSettingsOnConstruct()
+    {
+      var previous = RaygunSettings.Settings.IsRequestIpAddressMasked;
+      RaygunSettings.Settings.IsRequestIpAddressMasked = true;
+
+      try
+      {
+        var client = new FakeRaygunWebApiClient("API_KEY");
+
+        Assert.That(client.IsRequestIpAddressMasked, Is.True);
+        Assert.That(client.ExposeRequestMessageOptions.IsRequestIpAddressMasked, Is.True);
+      }
+      finally
+      {
+        RaygunSettings.Settings.IsRequestIpAddressMasked = previous;
+      }
+    }
+
+    [Test]
+    public void RequestIpAddressMaskingFlowsFromClientToBuiltRequestMessage()
+    {
+      using (var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, "http://example.com"))
+      {
+        request.Content = new System.Net.Http.StringContent(string.Empty);
+        dynamic context = new System.Dynamic.ExpandoObject();
+        context.Request = new System.Dynamic.ExpandoObject();
+        context.Request.UserHostAddress = "192.168.12.123";
+        request.Properties["MS_HttpContext"] = context;
+
+        var client = new FakeRaygunWebApiClient("API_KEY")
+        {
+          IsRequestIpAddressMasked = true
+        };
+
+        var message = Mindscape.Raygun4Net.WebApi.Builders.RaygunWebApiRequestMessageBuilder.Build(
+          request,
+          client.ExposeRequestMessageOptions);
+
+        Assert.That(message.IPAddress, Is.EqualTo("192.168.12.0"));
+      }
+    }
+
+    [Test]
     public void CanNotSendIfExcludingStatusCode()
     {
       RaygunSettings.Settings.ExcludeHttpStatusCodesList = "404";

--- a/Mindscape.Raygun4Net.WebApi/Builders/RaygunRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/Builders/RaygunRequestMessageBuilder.cs
@@ -5,7 +5,6 @@ using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Web;
 using Mindscape.Raygun4Net.Messages;
 using Mindscape.Raygun4Net.Filters;
@@ -15,8 +14,6 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
 {
   public class RaygunRequestMessageBuilder
   {
-    private static readonly Regex IpAddressRegex = new Regex(@"\A(?:\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b)(:[1-9][0-9]{0,4})?\z", RegexOptions.Compiled);
-
     private const int MAX_RAW_DATA_LENGTH = 4096; // bytes
     private const int MAX_KEY_LENGTH = 256; // Characters
     private const int MAX_VALUE_LENGTH = 256; // Characters
@@ -27,7 +24,7 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
 
       RaygunRequestMessage message = new RaygunRequestMessage()
       {
-        IPAddress   = GetIpAddress(request),
+        IPAddress   = GetIpAddress(request, options),
         QueryString = GetQueryString(request, options),
         Cookies     = GetCookies(request, options),
         Data        = GetServerVariables(request, options),
@@ -50,7 +47,7 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
       return message;
     }
 
-    private static string GetIpAddress(HttpRequest request)
+    private static string GetIpAddress(HttpRequest request, RaygunRequestMessageOptions options)
     {
       string strIp = null;
 
@@ -95,16 +92,12 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
         RaygunLogger.Instance.Error($"Failed to get IP address: {ex.Message}");
       }
 
-      return strIp;
+      return options.IsRequestIpAddressMasked ? IpAddressMasker.Mask(strIp) : strIp;
     }
 
     private static bool IsValidIpAddress(string strIp)
     {
-      if (strIp != null)
-      {
-        return IpAddressRegex.IsMatch(strIp.Trim());
-      }
-      return false;
+      return IpAddressMasker.IsValidAddress(strIp);
     }
 
     private static IDictionary GetQueryString(HttpRequest request, RaygunRequestMessageOptions options)

--- a/Mindscape.Raygun4Net.WebApi/Builders/RaygunRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/Builders/RaygunRequestMessageBuilder.cs
@@ -130,7 +130,11 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
       IDictionary serverVariables = new Dictionary<string, string>();
       try
       {
-        serverVariables = ToDictionary(request.ServerVariables, options.IsServerVariableIgnored, options.IsSensitiveFieldIgnored);
+        serverVariables = ToDictionary(
+          request.ServerVariables,
+          key => options.IsServerVariableIgnored(key) ||
+                 (options.IsRequestIpAddressMasked && IpAddressMasker.IsClientIpAddressServerVariable(key)),
+          options.IsSensitiveFieldIgnored);
         serverVariables.Remove("ALL_HTTP");
         serverVariables.Remove("HTTP_COOKIE");
         serverVariables.Remove("ALL_RAW");
@@ -165,7 +169,11 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
 
       try
       {
-        headers = ToDictionary(request.Headers, options.IsHeaderIgnored, options.IsSensitiveFieldIgnored);
+        headers = ToDictionary(
+          request.Headers,
+          key => options.IsHeaderIgnored(key) ||
+                 (options.IsRequestIpAddressMasked && IpAddressMasker.IsClientIpAddressHeader(key)),
+          options.IsSensitiveFieldIgnored);
         headers.Remove("Cookie");
       }
       catch (Exception e)

--- a/Mindscape.Raygun4Net.WebApi/Builders/RaygunWebApiRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/Builders/RaygunWebApiRequestMessageBuilder.cs
@@ -121,7 +121,10 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
 
       try
       {
-        foreach (var header in request.Headers.Where(h => !options.IsHeaderIgnored(h.Key) && !options.IsSensitiveFieldIgnored(h.Key)))
+        foreach (var header in request.Headers.Where(h =>
+                   !options.IsHeaderIgnored(h.Key) &&
+                   !options.IsSensitiveFieldIgnored(h.Key) &&
+                   (!options.IsRequestIpAddressMasked || !IpAddressMasker.IsClientIpAddressHeader(h.Key))))
         {
           headers[header.Key] = string.Join(",", header.Value);
         }
@@ -130,7 +133,9 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
         {
           foreach (var header in request.Content.Headers)
           {
-            if (!options.IsHeaderIgnored(header.Key) && !options.IsSensitiveFieldIgnored(header.Key))
+            if (!options.IsHeaderIgnored(header.Key) &&
+                !options.IsSensitiveFieldIgnored(header.Key) &&
+                (!options.IsRequestIpAddressMasked || !IpAddressMasker.IsClientIpAddressHeader(header.Key)))
             {
               headers[header.Key] = string.Join(",", header.Value);
             }

--- a/Mindscape.Raygun4Net.WebApi/Builders/RaygunWebApiRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.WebApi/Builders/RaygunWebApiRequestMessageBuilder.cs
@@ -23,7 +23,7 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
 
       var message = new RaygunRequestMessage
       {
-        IPAddress   = GetIPAddress(request),
+        IPAddress   = GetIPAddress(request, options),
         QueryString = GetQueryString(request, options),
         Form        = GetForm(request, options),
         RawData     = GetRawData(request, options),
@@ -44,7 +44,7 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
       return message;
     }
 
-    private static string GetIPAddress(HttpRequestMessage request)
+    private static string GetIPAddress(HttpRequestMessage request, RaygunRequestMessageOptions options)
     {
       try
       {
@@ -54,7 +54,8 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
 
           if (ctx != null)
           {
-            return ctx.Request.UserHostAddress;
+            string address = ctx.Request.UserHostAddress;
+            return options.IsRequestIpAddressMasked ? IpAddressMasker.Mask(address) : address;
           }
         }
 
@@ -64,7 +65,8 @@ namespace Mindscape.Raygun4Net.WebApi.Builders
 
           if (remoteEndpoint != null)
           {
-            return remoteEndpoint.Address;
+            string address = remoteEndpoint.Address;
+            return options.IsRequestIpAddressMasked ? IpAddressMasker.Mask(address) : address;
           }
         }
       }

--- a/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
+++ b/Mindscape.Raygun4Net.WebApi/Mindscape.Raygun4Net.WebApi.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Compile Include="..\Shared\IpAddressMasker.cs" Link="IpAddressMasker.cs" />
     <Compile Include="..\Mindscape.Raygun4Net4\ThrottledBackgroundMessageProcessor.cs">
       <Link>ThrottledBackgroundMessageProcessor.cs</Link>
     </Compile>

--- a/Mindscape.Raygun4Net.WebApi/README.md
+++ b/Mindscape.Raygun4Net.WebApi/README.md
@@ -146,13 +146,13 @@ i.e. A way to prevent local debug/development from notifying Raygun without havi
 Mask request IP addresses
 -------------------------
 
-Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses and the embedded IPv4 portion of IPv4-mapped IPv6 addresses to a `/24` prefix, and native IPv6 addresses to a `/48` prefix, while retaining any port:
 
 ```
 <RaygunSettings apikey="YOUR_APP_API_KEY" isRequestIpAddressMasked="true" />
 ```
 
-This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers or server variables, configure the relevant ignore settings as well.
+When enabled, Raygun also excludes known client-IP forwarding headers and server variables, such as `X-Forwarded-For`, `Forwarded`, and `REMOTE_ADDR`, from request metadata. Custom headers and arbitrary request fields are not scanned; configure the relevant ignore settings for any additional application-specific metadata.
 
 Remove sensitive request data
 -----------------------------

--- a/Mindscape.Raygun4Net.WebApi/README.md
+++ b/Mindscape.Raygun4Net.WebApi/README.md
@@ -143,6 +143,17 @@ i.e. A way to prevent local debug/development from notifying Raygun without havi
 <RaygunSettings apikey="YOUR_APP_API_KEY" excludeErrorsFromLocal="true" />
 ```
 
+Mask request IP addresses
+-------------------------
+
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+
+```
+<RaygunSettings apikey="YOUR_APP_API_KEY" isRequestIpAddressMasked="true" />
+```
+
+This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers or server variables, configure the relevant ignore settings as well.
+
 Remove sensitive request data
 -----------------------------
 

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -376,7 +376,9 @@ namespace Mindscape.Raygun4Net.WebApi
 
     /// <summary>
     /// Specifies whether request IP addresses are masked before being sent.
-    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// IPv4 and IPv4-mapped IPv6 addresses are masked to the embedded IPv4 /24 prefix;
+    /// native IPv6 addresses are masked to a /48 prefix. Known client-IP headers and server
+    /// variables are excluded from request metadata while masking is enabled.
     /// </summary>
     public bool IsRequestIpAddressMasked
     {

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -246,6 +246,7 @@ namespace Mindscape.Raygun4Net.WebApi
 
       IsRawDataIgnored = RaygunSettings.Settings.IsRawDataIgnored;
       IsRawDataIgnoredWhenFilteringFailed = RaygunSettings.Settings.IsRawDataIgnoredWhenFilteringFailed;
+      IsRequestIpAddressMasked = RaygunSettings.Settings.IsRequestIpAddressMasked;
 
       UseXmlRawDataFilter = RaygunSettings.Settings.UseXmlRawDataFilter;
       UseKeyValuePairRawDataFilter = RaygunSettings.Settings.UseKeyValuePairRawDataFilter;
@@ -371,6 +372,16 @@ namespace Mindscape.Raygun4Net.WebApi
     {
       get { return _requestMessageOptions.IsRawDataIgnoredWhenFilteringFailed; }
       set { _requestMessageOptions.IsRawDataIgnoredWhenFilteringFailed = value; }
+    }
+
+    /// <summary>
+    /// Specifies whether request IP addresses are masked before being sent.
+    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// </summary>
+    public bool IsRequestIpAddressMasked
+    {
+      get { return _requestMessageOptions.IsRequestIpAddressMasked; }
+      set { _requestMessageOptions.IsRequestIpAddressMasked = value; }
     }
 
     /// <summary>

--- a/Mindscape.Raygun4Net4.Tests/Model/FakeRaygunClient.cs
+++ b/Mindscape.Raygun4Net4.Tests/Model/FakeRaygunClient.cs
@@ -6,6 +6,20 @@ namespace Mindscape.Raygun4Net4.Tests
 {
   public class FakeRaygunClient : RaygunClient
   {
+    public FakeRaygunClient()
+    {
+    }
+
+    public FakeRaygunClient(string apiKey)
+      : base(apiKey)
+    {
+    }
+
+    public RaygunRequestMessageOptions ExposeRequestMessageOptions
+    {
+      get { return _requestMessageOptions; }
+    }
+
     public IEnumerable<Exception> ExposeStripWrapperExceptions(Exception exception)
     {
       return base.StripWrapperExceptions(exception);

--- a/Mindscape.Raygun4Net4.Tests/RaygunClientTests.cs
+++ b/Mindscape.Raygun4Net4.Tests/RaygunClientTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Web;
+using Mindscape.Raygun4Net;
 using NUnit.Framework;
 
 namespace Mindscape.Raygun4Net4.Tests
@@ -18,6 +19,65 @@ namespace Mindscape.Raygun4Net4.Tests
     public void SetUp()
     {
       _client = new FakeRaygunClient();
+    }
+
+    [Test]
+    public void RequestIpAddressMaskingCanBeConfigured()
+    {
+      _client.IsRequestIpAddressMasked = true;
+
+      Assert.That(_client.IsRequestIpAddressMasked, Is.True);
+    }
+
+    [Test]
+    public void RequestIpAddressMaskingIsCopiedFromSettingsOnConstruct()
+    {
+      var previous = RaygunSettings.Settings.IsRequestIpAddressMasked;
+      RaygunSettings.Settings.IsRequestIpAddressMasked = true;
+
+      try
+      {
+        var client = new FakeRaygunClient("API_KEY");
+
+        Assert.That(client.IsRequestIpAddressMasked, Is.True);
+        Assert.That(client.ExposeRequestMessageOptions.IsRequestIpAddressMasked, Is.True);
+      }
+      finally
+      {
+        RaygunSettings.Settings.IsRequestIpAddressMasked = previous;
+      }
+    }
+
+    [Test]
+    public void RequestIpAddressMaskingFlowsFromClientToBuiltRequestMessage()
+    {
+      var context = new HttpContext(new TestWorkerRequest("192.168.12.123"));
+      var client = new FakeRaygunClient("API_KEY")
+      {
+        IsRequestIpAddressMasked = true
+      };
+
+      var message = Mindscape.Raygun4Net.Builders.RaygunRequestMessageBuilder.Build(
+        context.Request,
+        client.ExposeRequestMessageOptions);
+
+      Assert.That(message.IPAddress, Is.EqualTo("192.168.12.0"));
+    }
+
+    private sealed class TestWorkerRequest : System.Web.Hosting.SimpleWorkerRequest
+    {
+      private readonly string _remoteAddress;
+
+      public TestWorkerRequest(string remoteAddress)
+        : base("/", string.Empty, new System.IO.StringWriter())
+      {
+        _remoteAddress = remoteAddress;
+      }
+
+      public override string GetRemoteAddress()
+      {
+        return _remoteAddress;
+      }
     }
 
     // Exception stripping tests

--- a/Mindscape.Raygun4Net4/Builders/RaygunRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net4/Builders/RaygunRequestMessageBuilder.cs
@@ -5,7 +5,6 @@ using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Web;
 using Mindscape.Raygun4Net.Messages;
 using Mindscape.Raygun4Net.Filters;
@@ -15,8 +14,6 @@ namespace Mindscape.Raygun4Net.Builders
 {
   public class RaygunRequestMessageBuilder
   {
-    private static readonly Regex IpAddressRegex = new Regex(@"\A(?:\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b)(:[1-9][0-9]{0,4})?\z", RegexOptions.Compiled);
-
     private const int MAX_RAW_DATA_LENGTH = 4096; // bytes
     private const int MAX_KEY_LENGTH = 256; // Characters
     private const int MAX_VALUE_LENGTH = 256; // Characters
@@ -27,7 +24,7 @@ namespace Mindscape.Raygun4Net.Builders
 
       RaygunRequestMessage message = new RaygunRequestMessage()
       {
-        IPAddress   = GetIpAddress(request),
+        IPAddress   = GetIpAddress(request, options),
         QueryString = GetQueryString(request, options),
         Cookies     = GetCookies(request, options),
         Data        = GetServerVariables(request, options),
@@ -50,7 +47,7 @@ namespace Mindscape.Raygun4Net.Builders
       return message;
     }
 
-    private static string GetIpAddress(HttpRequest request)
+    private static string GetIpAddress(HttpRequest request, RaygunRequestMessageOptions options)
     {
       string strIp = null;
 
@@ -95,16 +92,12 @@ namespace Mindscape.Raygun4Net.Builders
         RaygunLogger.Instance.Error($"Failed to get IP address: {ex.Message}");
       }
 
-      return strIp;
+      return options.IsRequestIpAddressMasked ? IpAddressMasker.Mask(strIp) : strIp;
     }
 
     private static bool IsValidIpAddress(string strIp)
     {
-      if (strIp != null)
-      {
-        return IpAddressRegex.IsMatch(strIp.Trim());
-      }
-      return false;
+      return IpAddressMasker.IsValidAddress(strIp);
     }
 
     private static IDictionary GetQueryString(HttpRequest request, RaygunRequestMessageOptions options)

--- a/Mindscape.Raygun4Net4/Builders/RaygunRequestMessageBuilder.cs
+++ b/Mindscape.Raygun4Net4/Builders/RaygunRequestMessageBuilder.cs
@@ -130,7 +130,11 @@ namespace Mindscape.Raygun4Net.Builders
       IDictionary serverVariables = new Dictionary<string, string>();
       try
       {
-        serverVariables = ToDictionary(request.ServerVariables, options.IsServerVariableIgnored, options.IsSensitiveFieldIgnored);
+        serverVariables = ToDictionary(
+          request.ServerVariables,
+          key => options.IsServerVariableIgnored(key) ||
+                 (options.IsRequestIpAddressMasked && IpAddressMasker.IsClientIpAddressServerVariable(key)),
+          options.IsSensitiveFieldIgnored);
         serverVariables.Remove("ALL_HTTP");
         serverVariables.Remove("HTTP_COOKIE");
         serverVariables.Remove("ALL_RAW");
@@ -165,7 +169,11 @@ namespace Mindscape.Raygun4Net.Builders
 
       try
       {
-        headers = ToDictionary(request.Headers, options.IsHeaderIgnored, options.IsSensitiveFieldIgnored);
+        headers = ToDictionary(
+          request.Headers,
+          key => options.IsHeaderIgnored(key) ||
+                 (options.IsRequestIpAddressMasked && IpAddressMasker.IsClientIpAddressHeader(key)),
+          options.IsSensitiveFieldIgnored);
         headers.Remove("Cookie");
       }
       catch (Exception e)

--- a/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
+++ b/Mindscape.Raygun4Net4/Mindscape.Raygun4Net4.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Compile Include="..\Shared\IpAddressMasker.cs" Link="IpAddressMasker.cs" />
     <ProjectReference Include="..\Mindscape.Raygun4Net.Core\Mindscape.Raygun4Net.Core.csproj"/>
   </ItemGroup>
 

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -23,7 +23,7 @@ namespace Mindscape.Raygun4Net
     private static object _sendLock = new object();
 
     private readonly string _apiKey;
-    private readonly RaygunRequestMessageOptions _requestMessageOptions = new RaygunRequestMessageOptions();
+    protected readonly RaygunRequestMessageOptions _requestMessageOptions = new RaygunRequestMessageOptions();
     private readonly List<Type> _wrapperExceptions = new List<Type>();
 
     private IRaygunOfflineStorage _offlineStorage = new IsolatedRaygunOfflineStorage();
@@ -106,6 +106,7 @@ namespace Mindscape.Raygun4Net
 
       IsRawDataIgnored = RaygunSettings.Settings.IsRawDataIgnored;
       IsRawDataIgnoredWhenFilteringFailed = RaygunSettings.Settings.IsRawDataIgnoredWhenFilteringFailed;
+      IsRequestIpAddressMasked = RaygunSettings.Settings.IsRequestIpAddressMasked;
 
       UseXmlRawDataFilter = RaygunSettings.Settings.UseXmlRawDataFilter;
       UseKeyValuePairRawDataFilter = RaygunSettings.Settings.UseKeyValuePairRawDataFilter;
@@ -239,6 +240,16 @@ namespace Mindscape.Raygun4Net
     {
       get { return _requestMessageOptions.IsRawDataIgnoredWhenFilteringFailed; }
       set { _requestMessageOptions.IsRawDataIgnoredWhenFilteringFailed = value; }
+    }
+
+    /// <summary>
+    /// Specifies whether request IP addresses are masked before being sent.
+    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// </summary>
+    public bool IsRequestIpAddressMasked
+    {
+      get { return _requestMessageOptions.IsRequestIpAddressMasked; }
+      set { _requestMessageOptions.IsRequestIpAddressMasked = value; }
     }
 
     /// <summary>

--- a/Mindscape.Raygun4Net4/RaygunClient.cs
+++ b/Mindscape.Raygun4Net4/RaygunClient.cs
@@ -244,7 +244,9 @@ namespace Mindscape.Raygun4Net
 
     /// <summary>
     /// Specifies whether request IP addresses are masked before being sent.
-    /// IPv4 addresses are masked to a /24 prefix and IPv6 addresses to a /48 prefix.
+    /// IPv4 and IPv4-mapped IPv6 addresses are masked to the embedded IPv4 /24 prefix;
+    /// native IPv6 addresses are masked to a /48 prefix. Known client-IP headers and server
+    /// variables are excluded from request metadata while masking is enabled.
     /// </summary>
     public bool IsRequestIpAddressMasked
     {

--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ Toggle this boolean and the HTTP module will not send errors to Raygun if the re
 <RaygunSettings apikey="YOUR_APP_API_KEY" excludeErrorsFromLocal="true" />
 ```
 
+**Mask request IP addresses**
+
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+
+```xml
+<RaygunSettings apikey="YOUR_APP_API_KEY" isRequestIpAddressMasked="true" />
+```
+
+This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers or server variables, configure the relevant ignore settings as well.
+
 **Remove sensitive request data**
 
 If you have sensitive data in an HTTP request that you wish to prevent being transmitted to Raygun, you can provide lists of possible keys (names) to remove.
@@ -455,5 +465,4 @@ The key has a maximum length of 100.
 `<RaygunSettings apikey="[Raygun4Net api key goes here]" throwOnError="true"/>`
 - These errors will start going to the event viewer or you could attach a trace listener and have them logged to a text file as well
 - There are many reasons why crash reports may not be sent through. In the Event that the error message mentions “*The underlying connection was closed: An unexpected error occurred on a send*.” This is probably a TLS handshake issue. Confirm this by inspecting the inner exception or the rest of the trace and look for cipher mismatch phrase. This will be a clear indication that there is a TLS issue. - To Resolve this Add the following global config where it is most convenient e.g. Global.asax  ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 Taking care not to include the less secure protocols like SSL3 and to some extent the TLS1.1.
-
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ Toggle this boolean and the HTTP module will not send errors to Raygun if the re
 
 **Mask request IP addresses**
 
-Request IP address masking is disabled by default. Enable it to mask IPv4 addresses to a `/24` prefix and IPv6 addresses to a `/48` prefix while retaining any port:
+Request IP address masking is disabled by default. Enable it to mask IPv4 addresses and the embedded IPv4 portion of IPv4-mapped IPv6 addresses to a `/24` prefix, and native IPv6 addresses to a `/48` prefix, while retaining any port:
 
 ```xml
 <RaygunSettings apikey="YOUR_APP_API_KEY" isRequestIpAddressMasked="true" />
 ```
 
-This masks the `RaygunRequestMessage.IPAddress` field only. If a proxy copies the original address into headers or server variables, configure the relevant ignore settings as well.
+When enabled, Raygun also excludes known client-IP forwarding headers and server variables, such as `X-Forwarded-For`, `Forwarded`, and `REMOTE_ADDR`, from request metadata. Custom headers and arbitrary request fields are not scanned; configure the relevant ignore settings for any additional application-specific metadata.
 
 **Remove sensitive request data**
 
@@ -465,4 +465,3 @@ The key has a maximum length of 100.
 `<RaygunSettings apikey="[Raygun4Net api key goes here]" throwOnError="true"/>`
 - These errors will start going to the event viewer or you could attach a trace listener and have them logged to a text file as well
 - There are many reasons why crash reports may not be sent through. In the Event that the error message mentions “*The underlying connection was closed: An unexpected error occurred on a send*.” This is probably a TLS handshake issue. Confirm this by inspecting the inner exception or the rest of the trace and look for cipher mismatch phrase. This will be a clear indication that there is a TLS issue. - To Resolve this Add the following global config where it is most convenient e.g. Global.asax  ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 Taking care not to include the less secure protocols like SSL3 and to some extent the TLS1.1.
-

--- a/Raygun4Net.AspNetCore.Tests/IpAddressMaskerTests.cs
+++ b/Raygun4Net.AspNetCore.Tests/IpAddressMaskerTests.cs
@@ -32,6 +32,12 @@ public class IpAddressMaskerTests
   [TestCase("192.168.12.123:65536", false)]
   [TestCase("192.168.12.123:abc", false)]
   [TestCase("192.168.12.123:", false)]
+  [TestCase("127.1", false)]
+  [TestCase("2130706433", false)]
+  [TestCase("0x7f000001", false)]
+  [TestCase("192.168.012.123", false)]
+  [TestCase(" 192.168.12.123 ", false)]
+  [TestCase("[192.168.12.123]", false)]
   [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", true)]
   [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]", true)]
   [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]:443", true)]
@@ -46,13 +52,42 @@ public class IpAddressMaskerTests
   [Test]
   public void IsValidAddressRejectsNull()
   {
-    IpAddressMasker.IsValidAddress(null!).Should().BeFalse();
+    IpAddressMasker.IsValidAddress(null).Should().BeFalse();
   }
 
   [Test]
   public void MaskPreservesNull()
   {
-    IpAddressMasker.Mask((string)null!).Should().BeNull();
+    IpAddressMasker.Mask((string?)null).Should().BeNull();
+  }
+
+  [TestCase("Forwarded")]
+  [TestCase("X-Forwarded-For")]
+  [TestCase("X-Real-IP")]
+  [TestCase("CF-Connecting-IP")]
+  [TestCase("true-client-ip")]
+  public void RecognizesKnownClientIpAddressHeaders(string name)
+  {
+    IpAddressMasker.IsClientIpAddressHeader(name).Should().BeTrue();
+  }
+
+  [TestCase("REMOTE_ADDR")]
+  [TestCase("REMOTE_HOST")]
+  [TestCase("HTTP_FORWARDED")]
+  [TestCase("HTTP_X_FORWARDED_FOR")]
+  [TestCase("http_x_real_ip")]
+  public void RecognizesKnownClientIpAddressServerVariables(string name)
+  {
+    IpAddressMasker.IsClientIpAddressServerVariable(name).Should().BeTrue();
+  }
+
+  [TestCase(null)]
+  [TestCase("")]
+  [TestCase("Authorization")]
+  [TestCase("X-Correlation-ID")]
+  public void DoesNotTreatUnrelatedHeadersAsClientIpAddresses(string? name)
+  {
+    IpAddressMasker.IsClientIpAddressHeader(name).Should().BeFalse();
   }
 
   [Test]

--- a/Raygun4Net.AspNetCore.Tests/IpAddressMaskerTests.cs
+++ b/Raygun4Net.AspNetCore.Tests/IpAddressMaskerTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+
+namespace Mindscape.Raygun4Net.AspNetCore.Tests;
+
+[TestFixture]
+public class IpAddressMaskerTests
+{
+  [TestCase("", "")]
+  [TestCase("not-an-ip-address", "not-an-ip-address")]
+  [TestCase("192.168.12.123", "192.168.12.0")]
+  [TestCase("192.168.12.123:8080", "192.168.12.0:8080")]
+  // Invalid / non-numeric ports: still mask the host for privacy
+  [TestCase("192.168.12.123:65536", "192.168.12.0:65536")]
+  [TestCase("192.168.12.123:abc", "192.168.12.0:abc")]
+  [TestCase("192.168.12.123:", "192.168.12.0:")]
+  [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", "2001:db8:1234::")]
+  [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]:443", "[2001:db8:1234::]:443")]
+  [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]:65536", "[2001:db8:1234::]:65536")]
+  [TestCase("::ffff:192.168.12.123", "::ffff:192.168.12.0")]
+  public void MaskHandlesSupportedAddressFormats(string address, string expected)
+  {
+    IpAddressMasker.Mask(address).Should().Be(expected);
+  }
+
+  [TestCase("", false)]
+  [TestCase("not-an-ip-address", false)]
+  [TestCase("192.168.12.123", true)]
+  [TestCase("192.168.12.123:8080", true)]
+  [TestCase("192.168.12.123:0", true)]
+  [TestCase("192.168.12.123:65535", true)]
+  // Invalid ports must not pass strict validation (XFF should not override REMOTE_ADDR)
+  [TestCase("192.168.12.123:65536", false)]
+  [TestCase("192.168.12.123:abc", false)]
+  [TestCase("192.168.12.123:", false)]
+  [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", true)]
+  [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]", true)]
+  [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]:443", true)]
+  [TestCase("[2001:db8:1234:5678:9abc:def0:1234:5678]:65536", false)]
+  [TestCase("::ffff:192.168.12.123", true)]
+  [TestCase("[2001:db8::1]junk", false)]
+  public void IsValidAddressAcceptsOnlyStrictAddressForms(string address, bool expected)
+  {
+    IpAddressMasker.IsValidAddress(address).Should().Be(expected);
+  }
+
+  [Test]
+  public void IsValidAddressRejectsNull()
+  {
+    IpAddressMasker.IsValidAddress(null!).Should().BeFalse();
+  }
+
+  [Test]
+  public void MaskPreservesNull()
+  {
+    IpAddressMasker.Mask((string)null!).Should().BeNull();
+  }
+
+  [Test]
+  public void MaskPreservesIpv6ScopeId()
+  {
+    var address = IPAddress.Parse("fe80::1234%7");
+
+    var maskedAddress = IpAddressMasker.Mask(address);
+
+    maskedAddress.ToString().Should().Be("fe80::%7");
+    maskedAddress.ScopeId.Should().Be(7);
+  }
+}

--- a/Raygun4Net.AspNetCore.Tests/RaygunAspNetCoreRequestMessageBuilderTests.cs
+++ b/Raygun4Net.AspNetCore.Tests/RaygunAspNetCoreRequestMessageBuilderTests.cs
@@ -1,10 +1,81 @@
 ﻿using Mindscape.Raygun4Net.AspNetCore.Builders;
 
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
 namespace Mindscape.Raygun4Net.AspNetCore.Tests;
 
 [TestFixture]
 public class RaygunAspNetCoreRequestMessageBuilderTests
 {
+  [Test]
+  public void RequestIpAddressMaskingIsDisabledByDefault()
+  {
+    new RaygunSettings().IsRequestIpAddressMasked.Should().BeFalse();
+  }
+
+  [Test]
+  public void IsRequestIpAddressMaskedBindsFromConfiguration()
+  {
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        ["RaygunSettings:IsRequestIpAddressMasked"] = "true"
+      })
+      .Build();
+
+    var settings = new RaygunSettings();
+    configuration.GetSection("RaygunSettings").Bind(settings);
+
+    settings.IsRequestIpAddressMasked.Should().BeTrue();
+  }
+
+  [TestCase("192.168.12.123", 8123, false, "192.168.12.123:8123")]
+  [TestCase("192.168.12.123", 8123, true, "192.168.12.0:8123")]
+  [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", 0, false, "2001:db8:1234:5678:9abc:def0:1234:5678")]
+  [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", 0, true, "2001:db8:1234::")]
+  // Unmasked IPv6 keeps the historical addr:port shape for compatibility
+  [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", 443, false, "2001:db8:1234:5678:9abc:def0:1234:5678:443")]
+  // Masked IPv6 uses unambiguous [addr]:port formatting
+  [TestCase("2001:db8:1234:5678:9abc:def0:1234:5678", 443, true, "[2001:db8:1234::]:443")]
+  public async Task BuildAppliesConfiguredIpAddressMasking(string address, int port, bool isMasked, string expected)
+  {
+    var context = new DefaultHttpContext();
+    context.Connection.RemoteIpAddress = IPAddress.Parse(address);
+    context.Connection.RemotePort = port;
+    var settings = new RaygunSettings
+    {
+      IsRequestIpAddressMasked = isMasked
+    };
+
+    var message = await RaygunAspNetCoreRequestMessageBuilder.Build(context, settings);
+
+    message.IPAddress.Should().Be(expected);
+  }
+
+  [Test]
+  public async Task ConfigurationBoundSettingsAreAppliedWhenBuildingRequestMessage()
+  {
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        ["RaygunSettings:IsRequestIpAddressMasked"] = "true"
+      })
+      .Build();
+
+    var settings = new RaygunSettings();
+    configuration.GetSection("RaygunSettings").Bind(settings);
+
+    var context = new DefaultHttpContext();
+    context.Connection.RemoteIpAddress = IPAddress.Parse("192.168.12.123");
+    context.Connection.RemotePort = 8123;
+
+    var message = await RaygunAspNetCoreRequestMessageBuilder.Build(context, settings);
+
+    message.IPAddress.Should().Be("192.168.12.0:8123");
+  }
+
   // Any
   [TestCase("Banana", "*", true)]
   [TestCase("Apple", "*", true)]

--- a/Raygun4Net.AspNetCore.Tests/RaygunAspNetCoreRequestMessageBuilderTests.cs
+++ b/Raygun4Net.AspNetCore.Tests/RaygunAspNetCoreRequestMessageBuilderTests.cs
@@ -76,6 +76,38 @@ public class RaygunAspNetCoreRequestMessageBuilderTests
     message.IPAddress.Should().Be("192.168.12.0:8123");
   }
 
+  [Test]
+  public async Task MaskingRemovesKnownClientIpHeadersFromRequestMetadata()
+  {
+    var context = new DefaultHttpContext();
+    context.Connection.RemoteIpAddress = IPAddress.Parse("192.168.12.123");
+    context.Request.Headers["X-Forwarded-For"] = "192.168.12.123";
+    context.Request.Headers["Forwarded"] = "for=192.168.12.123";
+    context.Request.Headers["X-Correlation-ID"] = "correlation-value";
+
+    var message = await RaygunAspNetCoreRequestMessageBuilder.Build(context, new RaygunSettings
+    {
+      IsRequestIpAddressMasked = true
+    });
+
+    message.IPAddress.Should().Be("192.168.12.0");
+    message.Headers.Contains("X-Forwarded-For").Should().BeFalse();
+    message.Headers.Contains("Forwarded").Should().BeFalse();
+    message.Headers["X-Correlation-ID"].Should().Be("correlation-value");
+  }
+
+  [Test]
+  public async Task DisabledMaskingRetainsClientIpHeaders()
+  {
+    var context = new DefaultHttpContext();
+    context.Connection.RemoteIpAddress = IPAddress.Parse("192.168.12.123");
+    context.Request.Headers["X-Forwarded-For"] = "192.168.12.123";
+
+    var message = await RaygunAspNetCoreRequestMessageBuilder.Build(context, new RaygunSettings());
+
+    message.Headers["X-Forwarded-For"].Should().Be("192.168.12.123");
+  }
+
   // Any
   [TestCase("Banana", "*", true)]
   [TestCase("Apple", "*", true)]

--- a/Shared/IpAddressMasker.cs
+++ b/Shared/IpAddressMasker.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Globalization;
 using System.Net;
@@ -9,30 +11,52 @@ namespace Mindscape.Raygun4Net
   {
     private const int Ipv6PrefixLengthInBytes = 6;
 
+    private static readonly string[] ClientIpAddressHeaderNames =
+    {
+      "CF-Connecting-IP",
+      "Client-IP",
+      "Fastly-Client-IP",
+      "Fly-Client-IP",
+      "Forwarded",
+      "True-Client-IP",
+      "X-Client-IP",
+      "X-Cluster-Client-IP",
+      "X-Forwarded",
+      "X-Forwarded-For",
+      "X-Original-Forwarded-For",
+      "X-Real-IP"
+    };
+
     /// <summary>
     /// Strict validation for accepting client addresses from headers / server variables
-    /// (e.g. X-Forwarded-For, REMOTE_ADDR). Requires a parseable IP and, if a port is present,
-    /// a numeric port in the range 0–65535. Invalid port suffixes are rejected so they do not
-    /// override a valid REMOTE_ADDR.
+    /// (e.g. X-Forwarded-For, REMOTE_ADDR). IPv4 values must use four decimal octets without
+    /// leading zeros. If a port is present, it must be numeric and in the range 0–65535.
+    /// Invalid values are rejected so they do not override a valid REMOTE_ADDR.
     /// </summary>
-    internal static bool IsValidAddress(string address)
+    internal static bool IsValidAddress(string? address)
     {
-      return TryParseAddress(address, requireValidPort: true, out _, out _, out _);
+      if (address == null || string.IsNullOrWhiteSpace(address) || address.Length != address.Trim().Length)
+      {
+        return false;
+      }
+
+      return TryParseAddress(address, requireCanonicalIpv4: true, requireValidPort: true, out _, out _, out _);
     }
 
     /// <summary>
     /// Best-effort masking for privacy. If the host portion is a parseable IP, it is masked even
     /// when an attached port/suffix is malformed (host is redacted; original suffix is kept).
     /// </summary>
-    internal static string Mask(string address)
+    internal static string? Mask(string? address)
     {
-      if (string.IsNullOrWhiteSpace(address))
+      if (address == null || string.IsNullOrWhiteSpace(address))
       {
         return address;
       }
 
       string value = address.Trim();
-      if (!TryParseAddress(value, requireValidPort: false, out IPAddress ipAddress, out string prefix, out string suffix))
+      if (!TryParseAddress(value, requireCanonicalIpv4: false, requireValidPort: false, out IPAddress? ipAddress, out string prefix, out string suffix) ||
+          ipAddress == null)
       {
         return address;
       }
@@ -69,7 +93,48 @@ namespace Mindscape.Raygun4Net
       return address;
     }
 
-    private static bool TryParseAddress(string value, bool requireValidPort, out IPAddress address, out string prefix, out string suffix)
+    internal static bool IsClientIpAddressHeader(string? name)
+    {
+      if (name == null || string.IsNullOrEmpty(name))
+      {
+        return false;
+      }
+
+      foreach (string headerName in ClientIpAddressHeaderNames)
+      {
+        if (headerName.Equals(name, StringComparison.OrdinalIgnoreCase))
+        {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    internal static bool IsClientIpAddressServerVariable(string? name)
+    {
+      if (name == null || string.IsNullOrEmpty(name))
+      {
+        return false;
+      }
+
+      if (name.Equals("REMOTE_ADDR", StringComparison.OrdinalIgnoreCase) ||
+          name.Equals("REMOTE_HOST", StringComparison.OrdinalIgnoreCase))
+      {
+        return true;
+      }
+
+      const string headerPrefix = "HTTP_";
+      if (!name.StartsWith(headerPrefix, StringComparison.OrdinalIgnoreCase))
+      {
+        return false;
+      }
+
+      string headerName = name.Substring(headerPrefix.Length).Replace('_', '-');
+      return IsClientIpAddressHeader(headerName);
+    }
+
+    private static bool TryParseAddress(string value, bool requireCanonicalIpv4, bool requireValidPort, out IPAddress? address, out string prefix, out string suffix)
     {
       address = null;
       prefix = string.Empty;
@@ -80,7 +145,7 @@ namespace Mindscape.Raygun4Net
         return false;
       }
 
-      if (TryParseBracketedAddress(value, requireValidPort, out address, out suffix))
+      if (TryParseBracketedAddress(value, requireCanonicalIpv4, requireValidPort, out address, out suffix))
       {
         prefix = "[";
         return true;
@@ -94,15 +159,15 @@ namespace Mindscape.Raygun4Net
         return false;
       }
 
-      if (IPAddress.TryParse(value, out address))
+      if (TryParseUnbracketedAddress(value, requireCanonicalIpv4, out address))
       {
         return true;
       }
 
-      return TryParseIpv4AddressWithPort(value, requireValidPort, out address, out suffix);
+      return TryParseIpv4AddressWithPort(value, requireCanonicalIpv4, requireValidPort, out address, out suffix);
     }
 
-    private static bool TryParseBracketedAddress(string value, bool requireValidPort, out IPAddress address, out string suffix)
+    private static bool TryParseBracketedAddress(string value, bool requireCanonicalIpv4, bool requireValidPort, out IPAddress? address, out string suffix)
     {
       address = null;
       suffix = string.Empty;
@@ -114,8 +179,11 @@ namespace Mindscape.Raygun4Net
 
       int closingBracket = value.IndexOf(']');
       if (closingBracket < 0 ||
-          !IPAddress.TryParse(value.Substring(1, closingBracket - 1), out address))
+          !IPAddress.TryParse(value.Substring(1, closingBracket - 1), out address) ||
+          address == null ||
+          (requireCanonicalIpv4 && address.AddressFamily != AddressFamily.InterNetworkV6))
       {
+        address = null;
         return false;
       }
 
@@ -136,7 +204,26 @@ namespace Mindscape.Raygun4Net
       return true;
     }
 
-    private static bool TryParseIpv4AddressWithPort(string value, bool requireValidPort, out IPAddress address, out string suffix)
+    private static bool TryParseUnbracketedAddress(string value, bool requireCanonicalIpv4, out IPAddress? address)
+    {
+      if (!IPAddress.TryParse(value, out address) || address == null)
+      {
+        address = null;
+        return false;
+      }
+
+      if (requireCanonicalIpv4 &&
+          address.AddressFamily == AddressFamily.InterNetwork &&
+          !TryParseCanonicalIpv4Address(value, out address))
+      {
+        address = null;
+        return false;
+      }
+
+      return true;
+    }
+
+    private static bool TryParseIpv4AddressWithPort(string value, bool requireCanonicalIpv4, bool requireValidPort, out IPAddress? address, out string suffix)
     {
       address = null;
       suffix = string.Empty;
@@ -157,7 +244,13 @@ namespace Mindscape.Raygun4Net
 
       // Host portion must be IPv4. For masking (requireValidPort == false), the port/suffix may be
       // invalid, empty, or non-numeric — still parse so the host can be redacted.
-      if (!IPAddress.TryParse(value.Substring(0, separator), out address) ||
+      string host = value.Substring(0, separator);
+      bool isAddressParsed = requireCanonicalIpv4
+        ? TryParseCanonicalIpv4Address(host, out address)
+        : IPAddress.TryParse(host, out address);
+
+      if (!isAddressParsed ||
+          address == null ||
           address.AddressFamily != AddressFamily.InterNetwork)
       {
         address = null;
@@ -165,6 +258,31 @@ namespace Mindscape.Raygun4Net
       }
 
       suffix = portSuffix;
+      return true;
+    }
+
+    private static bool TryParseCanonicalIpv4Address(string value, out IPAddress? address)
+    {
+      address = null;
+      string[] components = value.Split('.');
+      if (components.Length != 4)
+      {
+        return false;
+      }
+
+      byte[] bytes = new byte[4];
+      for (int index = 0; index < components.Length; index++)
+      {
+        string component = components[index];
+        if (component.Length == 0 ||
+            (component.Length > 1 && component[0] == '0') ||
+            !byte.TryParse(component, NumberStyles.None, CultureInfo.InvariantCulture, out bytes[index]))
+        {
+          return false;
+        }
+      }
+
+      address = new IPAddress(bytes);
       return true;
     }
 

--- a/Shared/IpAddressMasker.cs
+++ b/Shared/IpAddressMasker.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Mindscape.Raygun4Net
+{
+  internal static class IpAddressMasker
+  {
+    private const int Ipv6PrefixLengthInBytes = 6;
+
+    /// <summary>
+    /// Strict validation for accepting client addresses from headers / server variables
+    /// (e.g. X-Forwarded-For, REMOTE_ADDR). Requires a parseable IP and, if a port is present,
+    /// a numeric port in the range 0–65535. Invalid port suffixes are rejected so they do not
+    /// override a valid REMOTE_ADDR.
+    /// </summary>
+    internal static bool IsValidAddress(string address)
+    {
+      return TryParseAddress(address, requireValidPort: true, out _, out _, out _);
+    }
+
+    /// <summary>
+    /// Best-effort masking for privacy. If the host portion is a parseable IP, it is masked even
+    /// when an attached port/suffix is malformed (host is redacted; original suffix is kept).
+    /// </summary>
+    internal static string Mask(string address)
+    {
+      if (string.IsNullOrWhiteSpace(address))
+      {
+        return address;
+      }
+
+      string value = address.Trim();
+      if (!TryParseAddress(value, requireValidPort: false, out IPAddress ipAddress, out string prefix, out string suffix))
+      {
+        return address;
+      }
+
+      return prefix + Mask(ipAddress) + suffix;
+    }
+
+    internal static IPAddress Mask(IPAddress address)
+    {
+      if (address == null)
+      {
+        throw new ArgumentNullException(nameof(address));
+      }
+
+      if (address.IsIPv4MappedToIPv6)
+      {
+        return Mask(address.MapToIPv4()).MapToIPv6();
+      }
+
+      byte[] bytes = address.GetAddressBytes();
+
+      if (address.AddressFamily == AddressFamily.InterNetwork)
+      {
+        bytes[bytes.Length - 1] = 0;
+        return new IPAddress(bytes);
+      }
+
+      if (address.AddressFamily == AddressFamily.InterNetworkV6)
+      {
+        Array.Clear(bytes, Ipv6PrefixLengthInBytes, bytes.Length - Ipv6PrefixLengthInBytes);
+        return new IPAddress(bytes, address.ScopeId);
+      }
+
+      return address;
+    }
+
+    private static bool TryParseAddress(string value, bool requireValidPort, out IPAddress address, out string prefix, out string suffix)
+    {
+      address = null;
+      prefix = string.Empty;
+      suffix = string.Empty;
+
+      if (string.IsNullOrWhiteSpace(value))
+      {
+        return false;
+      }
+
+      if (TryParseBracketedAddress(value, requireValidPort, out address, out suffix))
+      {
+        prefix = "[";
+        return true;
+      }
+
+      // Bracketed forms are only handled above. Do not fall through to IPAddress.TryParse:
+      // on modern .NET it accepts "[ipv6]:port" (including invalid ports), which would bypass
+      // strict port validation used for X-Forwarded-For / REMOTE_ADDR acceptance.
+      if (value.Length >= 2 && value[0] == '[')
+      {
+        return false;
+      }
+
+      if (IPAddress.TryParse(value, out address))
+      {
+        return true;
+      }
+
+      return TryParseIpv4AddressWithPort(value, requireValidPort, out address, out suffix);
+    }
+
+    private static bool TryParseBracketedAddress(string value, bool requireValidPort, out IPAddress address, out string suffix)
+    {
+      address = null;
+      suffix = string.Empty;
+
+      if (value.Length < 2 || value[0] != '[')
+      {
+        return false;
+      }
+
+      int closingBracket = value.IndexOf(']');
+      if (closingBracket < 0 ||
+          !IPAddress.TryParse(value.Substring(1, closingBracket - 1), out address))
+      {
+        return false;
+      }
+
+      string remainder = value.Substring(closingBracket + 1);
+      if (remainder.Length > 0 && remainder[0] != ':')
+      {
+        address = null;
+        return false;
+      }
+
+      if (requireValidPort && !IsValidPortSuffix(remainder))
+      {
+        address = null;
+        return false;
+      }
+
+      suffix = "]" + remainder;
+      return true;
+    }
+
+    private static bool TryParseIpv4AddressWithPort(string value, bool requireValidPort, out IPAddress address, out string suffix)
+    {
+      address = null;
+      suffix = string.Empty;
+
+      int separator = value.LastIndexOf(':');
+      // Exactly one colon so we do not confuse IPv6 with IPv4:port.
+      if (separator <= 0 || value.IndexOf(':') != separator)
+      {
+        return false;
+      }
+
+      string portSuffix = value.Substring(separator);
+
+      if (requireValidPort && !IsValidPortSuffix(portSuffix))
+      {
+        return false;
+      }
+
+      // Host portion must be IPv4. For masking (requireValidPort == false), the port/suffix may be
+      // invalid, empty, or non-numeric — still parse so the host can be redacted.
+      if (!IPAddress.TryParse(value.Substring(0, separator), out address) ||
+          address.AddressFamily != AddressFamily.InterNetwork)
+      {
+        address = null;
+        return false;
+      }
+
+      suffix = portSuffix;
+      return true;
+    }
+
+    private static bool IsValidPortSuffix(string suffix)
+    {
+      if (suffix.Length == 0)
+      {
+        return true;
+      }
+
+      int port;
+      return suffix[0] == ':' &&
+             int.TryParse(suffix.Substring(1), NumberStyles.None, CultureInfo.InvariantCulture, out port) &&
+             port >= 0 &&
+             port <= ushort.MaxValue;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add opt-in request IP address masking across ASP.NET Core, MVC/.NET Framework, and Web API providers
- mask IPv4 addresses to a /24 prefix and IPv6 addresses to a /48 prefix while retaining ports
- strictly validate forwarded/server-variable address ports while keeping masking best-effort
- add configuration, documentation, and regression coverage for the new setting

## Why

Applications may need to reduce the precision of client IP addresses sent with crash reports for privacy or compliance reasons. The new `IsRequestIpAddressMasked` setting provides this behavior without changing the default for existing users.

Masking applies to `RaygunRequestMessage.IPAddress`. Forwarding headers or server variables may still need to be excluded separately when they contain the original address.

## Validation

- built all ASP.NET Core target frameworks: `netstandard2.0`, `net6.0`, `net7.0`, and `net8.0`
- built the .NET Framework, Web API, MVC, and affected test projects
- passed 56 focused IP masker and ASP.NET Core request builder tests
- verified the .NET Framework test assemblies compile; runtime execution is unavailable locally because Mono/.NET Framework is not installed


Due to being out of date, this branch supersedes #385 